### PR TITLE
[FIX] weird bug in adress_template. inheritance doesn't work when migrating from 10.0

### DIFF
--- a/commown/views/address_template.xml
+++ b/commown/views/address_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <template id="address" inherit_id="website_sale_payment_slimpay.address">
+  <template id="address" inherit_id="website_sale.address_b2b">
     <xpath expr="//form//input[@name='company_name']/ancestor::div[1]" position="replace"></xpath>
     <xpath expr="//form//input[@name='vat']/ancestor::div[1]" position="replace"></xpath>
     <!-- Add zip as required: -->


### PR DESCRIPTION
An error occures with migrated database from 10.0. (company_name not found).
(installation from scrach of ``commown`` module works correctly in V12).

As company_name and vat are defined in ``address_b2b``, the patch is correct and doesn't hurt IMO.

