### PR TITLE
[OU] commown_contractual_issue: migrate contract related to task (from account_analytic_account)

### DIFF
--- a/commown_contractual_issue/migrations/12.0.1.0.0/pre-migration.py
+++ b/commown_contractual_issue/migrations/12.0.1.0.0/pre-migration.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Sylvain LE GAL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from openupgradelib import openupgrade
+from psycopg2 import sql
+
+_logger = logging.getLogger(__name__)
+
+def create_contract_records(cr):
+    # Ref see :
+    # OCA/contract/contract/migrations/12.0.4.0.0/pre-migration.py
+    openupgrade.logged_query(
+        cr, sql.SQL("""
+        UPDATE account_analytic_account
+        SET partner_id = 1
+        WHERE id in (select distinct(contract_id) from project_task)
+        AND id not in (select id from contract_contract)
+        """),
+    )
+
+    openupgrade.logged_query(
+        cr, sql.SQL("""
+        INSERT INTO contract_contract
+        SELECT * FROM account_analytic_account
+        WHERE id in (select distinct(contract_id) from project_task)
+        AND id not in (select id from contract_contract)
+        """),
+    )
+    # Handle id sequence
+    cr.execute("SELECT setval('contract_contract_id_seq', "
+               "(SELECT MAX(id) FROM contract_contract))")
+    cr.execute("ALTER TABLE contract_contract ALTER id "
+               "SET DEFAULT NEXTVAL('contract_contract_id_seq')")
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+    create_contract_records(cr)


### PR DESCRIPTION
**Rational**
- ``account_analytic_account`` has been renamed into ``contract_contract``.
- contract are created here : https://github.com/OCA/contract/blob/12.0/contract/migrations/12.0.4.0.0/pre-migration.py#L95
- Only some analytic accounts are transformed intro contract.
- without that patch a FK error occurs on ``project_task.contract_id``

For the time being this patch create 3 contracts.

Note : 
Also partner_id is now required on contract_contract. We set "1" value. 