### PR TITLE
Display payment issues on contracts and update fr t10n accordingly

### DIFF
--- a/commown/i18n/fr.po
+++ b/commown/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-01 22:34+0000\n"
-"PO-Revision-Date: 2022-06-01 22:34+0000\n"
+"POT-Creation-Date: 2022-06-10 14:15+0000\n"
+"PO-Revision-Date: 2022-06-10 14:15+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -246,6 +246,11 @@ msgstr "Compte de pertes"
 #: model:ir.model.fields,field_description:commown.field_mass_reconcile_simple_partner_commown__account_profit_id
 msgid "Account Profit"
 msgstr "Compte de profits"
+
+#. module: commown
+#: model:ir.model,name:commown.model_account_reconciliation_widget
+msgid "Account Reconciliation widget"
+msgstr "outil de réconciliation de compte"
 
 #. module: commown
 #: model_terms:ir.ui.view,arch_db:commown.footer_custom
@@ -578,6 +583,11 @@ msgid "Payment Acquirer"
 msgstr "Intermédiaire de Paiement"
 
 #. module: commown
+#: model:ir.model.fields,field_description:commown.field_contract_contract__payment_issue_ids
+msgid "Payment issues"
+msgstr "Incidents de paiement"
+
+#. module: commown
 #: model:ir.model.fields,field_description:commown.field_contract_contract__transaction_label
 #: model:ir.model.fields,field_description:commown.field_contract_template__transaction_label
 msgid "Payment label"
@@ -747,12 +757,6 @@ msgstr "[${object.company_id.name}] Facture (Ref ${object.number or 'n/a'})"
 #: model:mail.template,subject:commown.mail_template_lead_start_error
 msgid "[Commown] ERROR starting crm.lead id ${object.id}"
 msgstr "[Commown] ERREUR lors du démarrage de l'opportunité id ${object.id}"
-
-#. module: commown
-#: model:base.automation,name:commown.order_sent
-#: model:ir.actions.server,name:commown.order_sent_ir_actions_server
-msgid "[Commown] Sale done"
-msgstr "[Commown] Commande effectuée"
 
 #. module: commown
 #: model:base.automation,name:commown.mail_message_arrival_concerning_issue

--- a/commown/models/contract.py
+++ b/commown/models/contract.py
@@ -27,6 +27,18 @@ class Contract(models.Model):
               'Possible markers: #START#, #END#, #INV# (invoice number)'),
     )
 
+    payment_issue_ids = fields.One2many(
+        comodel_name="project.task",
+        compute="_compute_payment_issues",
+        string="Payment issues",
+    )
+
+    def _compute_payment_issues(self):
+        for record in self:
+            record.payment_issue_ids = self.env["project.task"].search([
+                ("invoice_id", "in", record._get_related_invoices().ids),
+            ]).ids
+
     def name_get(self):
         result = []
         for record in self:

--- a/commown/views/contract_contract.xml
+++ b/commown/views/contract_contract.xml
@@ -32,4 +32,25 @@
     </field>
   </record>
 
+  <record id="contract_contract_customer_form_view"
+          model="ir.ui.view">
+    <field name="name">Contract form (in commown)</field>
+    <field name="model">contract.contract</field>
+    <field name="inherit_id" ref="commown_contractual_issue.contract_contract_customer_form_view"/>
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='issue_ids']" position="after">
+        <field name="payment_issue_ids" readonly="1">
+            <tree default_order="create_date">
+              <field name="name"/>
+              <field name="invoice_id"/>
+              <field name="stage_id"/>
+              <field name="invoice_unpaid_count"/>
+              <field name="invoice_next_payment_date"/>
+              <field name="create_date" invisible="1"/>
+            </tree>
+          </field>
+      </xpath>
+    </field>
+  </record>
+
 </odoo>


### PR DESCRIPTION
We use a dedicated unstored computed field for that purpose.
An alternative would have been to set contract_id on the project_task,
but this field has already a complex behaviour. Moreover, storing the
field's value has no real benefit here (search is not useful here).