### PR TITLE
Fix the no-issue-to-date contract variable discount condition

### DIFF
--- a/commown_contract_variable_discount/models/discount.py
+++ b/commown_contract_variable_discount/models/discount.py
@@ -35,8 +35,9 @@ class ContractTemplateAbstractDiscountLine(models.AbstractModel):
     def _compute_condition_no_issue_to_date(self, line, date):
         return not [
             t for t in line.contract_id.issue_ids
-            if (not t.penalty_exemption
-                and fields.Date.from_string(t.contractual_issue_date) < date)
+            if (t.contractual_issue_type
+                and not t.penalty_exemption
+                and t.contractual_issue_date < date)
         ]
 
     def _compute_condition_coupon_from_campaign(self, line, date):

--- a/commown_contract_variable_discount/tests/test_discount.py
+++ b/commown_contract_variable_discount/tests/test_discount.py
@@ -20,12 +20,17 @@ class DiscountLineTC(TestContractBase):
             "condition": "no_issue_to_date",
         })
 
+        # Add a non-contractual issue (to check it does not raise a bug)
+        self.contract.issue_ids |= self.env['project.task'].create({
+            "name": "task0",
+        })
+
         # Test without penalty
-        self.assertFalse(self.contract.issue_ids)
         self.contract.issue_ids |= self.env['project.task'].create({
             "name": "task1",
             "penalty_exemption": True,
             "contractual_issue_date": self.contract.date_start,
+            "contractual_issue_type": "loss",
         })
 
         inv1 = self.contract.recurring_create_invoice()
@@ -36,6 +41,7 @@ class DiscountLineTC(TestContractBase):
             "name": "task2",
             "penalty_exemption": False,
             "contractual_issue_date": self.contract.date_start,
+            "contractual_issue_type": "theft",
         })
 
         inv2 = self.contract.recurring_create_invoice()


### PR DESCRIPTION
The tests needed to be completed and fixed to show the bug: a crash
when applying the condition when a task related to the contract was
not a contractual issue (i.e. had a NULL contractual_issue_type).