### PR TITLE
Add an inverse function on contract computed field recurring_next_date

### DIFF
--- a/product_rental/tests/__init__.py
+++ b/product_rental/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_contract
 from . import test_sale_order
 from . import test_website

--- a/product_rental/tests/test_contract.py
+++ b/product_rental/tests/test_contract.py
@@ -1,0 +1,29 @@
+from odoo.addons.contract.tests.test_contract import TestContractBase
+from odoo.exceptions import ValidationError
+
+
+class ContractTC(TestContractBase):
+
+    def test_inverse_recurring_next_date_error(self):
+        self.contract.is_auto_pay = False
+        init_recurring_next_date = self.contract.recurring_next_date
+        inv = self.contract.recurring_create_invoice()
+
+        with self.assertRaises(ValidationError) as err:
+            self.contract.recurring_next_date = init_recurring_next_date
+
+        self.assertIn("There are invoices past the new next recurring date",
+                      str(err.exception))
+
+    def test_inverse_recurring_next_date_ok(self):
+        self.contract.is_auto_pay = False
+        init_recurring_next_date = self.contract.recurring_next_date
+        inv = self.contract.recurring_create_invoice()
+
+        inv.unlink()
+        self.contract.recurring_next_date = init_recurring_next_date
+
+        self.assertEqual(
+            set(self.contract.mapped("contract_line_ids.recurring_next_date")),
+            {init_recurring_next_date}
+        )


### PR DESCRIPTION
This is useful for scenarii where you generate the next invoice just
for debugging purposes, and want to go back to previous situation.
(under the constant hypothesis that all contract lines have the same
 dates).