### PR TITLE
Fix crash on shop display of rental but non-contract products

### DIFF
--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -75,7 +75,7 @@
   <template id="product_price_b2b" inherit_id="website_sale_b2b.product_price_b2b">
 
     <!-- Add attribute-value dependent show/ hide html functions -->
-    <xpath expr="div[@t-if='product.is_rental']" position="inside">
+    <xpath expr="div[@id='product_rental_price']" position="inside">
       <script type="text/javascript"
               src="/commown/static/src/js/website_sale.js"></script>
       <!-- Example usage

--- a/product_rental/controllers/main.py
+++ b/product_rental/controllers/main.py
@@ -8,15 +8,18 @@ class RentalProductWebsiteSale(WebsiteSale):
     @http.route()
     def product(self, product, category='', search='', **kwargs):
         result = super().product(product, category='', search='', **kwargs)
-        if product.is_rental and product.is_contract:
-            ct = product.sudo().property_contract_template_id
-            rtypes = dict(ct.fields_get()['commitment_period_type']['selection'])
+        if product.is_rental:
             result.qcontext.update({
-                "commitment_period": {
-                    "number": ct.commitment_period_number,
-                    "type": rtypes[ct.commitment_period_type].lower(),
-                },
                 "rental_price_base": product.rental_price,
                 "rental_price_ratio": product.rental_price_ratio(),
             })
+            if product.is_contract:
+                ct = product.sudo().property_contract_template_id
+                rtypes = dict(ct.fields_get()['commitment_period_type']['selection'])
+                result.qcontext.update({
+                    "commitment_period": {
+                        "number": ct.commitment_period_number,
+                        "type": rtypes[ct.commitment_period_type].lower(),
+                    },
+                })
         return result

--- a/product_rental/views/website_sale_templates.xml
+++ b/product_rental/views/website_sale_templates.xml
@@ -41,8 +41,10 @@
     </xpath>
 
     <xpath expr="div" position="after">
-      <div t-if="product.is_rental" class="product_price mt16">
-        <p t-if="commitment_period['number'] > 0">
+      <div t-if="product.is_rental"
+           id="product_rental_price"
+           class="product_price mt16">
+        <p t-if="product.is_contract and commitment_period['number'] > 0">
           <b class="commitment"><span>Commitment duration: </span><span t-esc="commitment_period['number']"/> <span t-esc="commitment_period['type']"/></b>
         </p>
         <h4 class="oe_price_h4 css_editable_mode_hidden">


### PR DESCRIPTION
This is typically the case of accessories (keyboard, ...), which need
to be rented with a contract product (computer), but cannot otherwise.