### PR TITLE
Add missing portal permissions to access the discuss app

### DIFF
--- a/commown/__manifest__.py
+++ b/commown/__manifest__.py
@@ -57,6 +57,7 @@
         'data/mail_templates.xml',
         'data/project_project.xml',
         'data/product_public_category.xml',
+        'security/ir.model.access.csv',
         'views/account_invoice.xml',
         'views/actions_account_invoice.xml',
         'views/actions_crm_lead.xml',

--- a/commown/security/ir.model.access.csv
+++ b/commown/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ir_ui_menu_group_portal,ir.ui.menu_portal,base.model_ir_ui_menu,base.group_portal,1,0,0,0
+access_calendar_attendee_group_portal,calendar.attendee_portal,calendar.model_calendar_attendee,base.group_portal,1,0,0,0
+access_ir_model_group_portal,ir.model_portal,base.model_ir_model,base.group_portal,1,0,0,0


### PR DESCRIPTION
Those was removed in 11.0, see at least https://github.com/odoo/odoo/pull/57180