### PR TITLE
Remove contract creation button from the sale order form

### DIFF
--- a/product_rental/__manifest__.py
+++ b/product_rental/__manifest__.py
@@ -22,6 +22,7 @@
         "views/portal_contract.xml",
         "views/payment_transaction.xml",
         "views/product_template.xml",
+        "views/sale_order.xml",
         "views/website_sale_templates.xml",
     ],
     "demo": ["demo/data.xml"],

--- a/product_rental/views/sale_order.xml
+++ b/product_rental/views/sale_order.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<odoo>
+
+  <record id="view_order_form" model="ir.ui.view">
+    <field name="name">sale.order.form (in product_rental)</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="product_contract.view_order_form"/>
+
+    <!-- Remove the contract creation button -->
+    <field name="arch" type="xml">
+      <xpath expr="//button[@name='action_create_contract']" position="replace"></xpath>
+    </field>
+
+  </record>
+
+</odoo>


### PR DESCRIPTION
Contracts are automatically created, so this is confusing and could lead
to duplicate contracts.