### PR TITLE
Fix new delivery date changing contract start date

### DIFF
--- a/commown/models/crm_lead.py
+++ b/commown/models/crm_lead.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from odoo import api, models
 
 
@@ -11,8 +13,12 @@ class CrmLead(models.Model):
     @api.multi
     def delivery_perform_actions(self):
         super(CrmLead, self).delivery_perform_actions()
+        today = date.today()
         for record in self:
             contract = record.contract_id.sudo()
+            # Do not restart contract that have already started
+            if contract.date_start and contract.date_start <= today:
+                continue
             for cline in contract.contract_line_ids:
                 cline.date_start = record.delivery_date
                 cline._onchange_date_start()

--- a/commown/tests/test_crm_lead.py
+++ b/commown/tests/test_crm_lead.py
@@ -62,3 +62,8 @@ class CrmLeadTC(RentalSaleOrderTC):
         # Check results: contract started but is_auto_pay unchanged
         self.assertEqual(contract.date_start, date(2018, 1, 1))
         self.assertFalse(contract.is_auto_pay)
+
+        # Simulate delivery again: happens when we send a new device
+        # Contract start date should not change again!
+        lead.delivery_date = date(2017, 1, 1)
+        self.assertEqual(contract.date_start, date(2018, 1, 1))


### PR DESCRIPTION
When a new device is delivered for an already running contract, its start date must not change.