### PR TITLE
Show the contract template line on contract line form

### DIFF
--- a/contract_variable_discount/views/contract.xml
+++ b/contract_variable_discount/views/contract.xml
@@ -38,6 +38,11 @@
     <field name="model">contract.line</field>
     <field name="inherit_id" ref="contract.contract_line_form_view"/>
     <field name="arch" type="xml">
+
+      <field name="discount" position="after">
+        <field name="contract_template_line_id"/>
+      </field>
+
       <group name="note_invoicing_mode" position="before">
         <group name="Variable discount">
           <field name="inherited_discount_line_ids"/>
@@ -45,6 +50,7 @@
           <field name="contract_template_line_id" invisible="1"/>
         </group>
       </group>
+
     </field>
   </record>
 


### PR DESCRIPTION
This makes it possible to add a new contract line but still
inherit the discount line definitions of the corresponding
template line.