### PR TITLE
Fix a UI crash when editing contract lines after displaying contract through a button

### DIFF
--- a/commown_lead_risk_analysis/models/crm_lead.py
+++ b/commown_lead_risk_analysis/models/crm_lead.py
@@ -157,10 +157,14 @@ class CommownCrmLead(models.Model):
     def button_open_contract(self):
         contract = self.contract_id
         if contract:
-            return {
-                "type": "ir.actions.act_window",
-                "res_model": "contract.contract",
-                "res_id": contract.id,
-                "name": _("Related contract"),
-                "views": [(False, "form")],
-            }
+            result = contract.get_formview_action()
+
+            # Fix a bug (in the js engine?) that leads to a UI crash when
+            # adding a contract line to the displayed contract: without this,
+            # the active_id is the crm lead, and is (erronously) used as the
+            # contract id to add contract lines to.
+            # Note that the same bug is present in the product_contract module
+            # (button calling sale.order's action_show_contracts method)
+            result["context"] = {"active_id": contract.id}
+
+            return result

--- a/product_rental/models/sale_order.py
+++ b/product_rental/models/sale_order.py
@@ -180,3 +180,16 @@ class ProductRentalSaleOrder(models.Model):
             self._add_analytic_account(contract)
 
         return contracts
+
+    def action_show_contracts(self):
+        """Fix product_contract implementation of this same method
+
+        Fix a bug (in the js engine?) that leads to a UI crash when
+        adding a contract line to the displayed contract: without this,
+        the active_id is the sale order, and is (erronously) used as the
+        contract id to add contract lines to.
+        """
+        result = super().action_show_contracts()
+        if result["view_mode"] == "form":
+            result["context"] = {"active_id": result["res_id"]}
+        return result


### PR DESCRIPTION
This UI crash reads "Record does not exist or has been deleted." with the wrong contract id.
This is probably a js engine bug, where the current active_id is used as the contract id
once displayed and edited.