### PR TITLE
Improve shipping partner choice on crm.lead using sale.order shipping partner

### DIFF
--- a/commown_shipping/models/crm_lead.py
+++ b/commown_shipping/models/crm_lead.py
@@ -45,3 +45,13 @@ class CrmLead(models.Model):
             return self._print_parcel_labels(
                 self._default_shipping_parcel_type(), force_single=force_single
             )
+
+    def _recipient_partner(self):
+        "Override recipient partner computation to use the sale.order if any"
+        self.ensure_one()
+
+        return (
+            self.recipient_partner_id
+            or self.mapped("so_line_id.order_id.partner_shipping_id")
+            or super(CrmLead, self)._recipient_partner()
+        )

--- a/commown_shipping/tests/test_crm_lead.py
+++ b/commown_shipping/tests/test_crm_lead.py
@@ -116,7 +116,7 @@ class CrmLeadShippingTC(MockedEmptySessionMixin, BaseShippingTC):
         for num in range(5):
             leads += self.lead.copy({"name": "[SO%05d] Test lead" % num})
             if num == 3:
-                leads[-1].partner_id = other_partner
+                leads[-1].recipient_partner_id = other_partner
 
         with self.assertRaises(UserError) as err:
             self._print_outward_labels(leads)


### PR DESCRIPTION
This is mostly useful in B2C, making sure the sale.order shipping id is used by default
when generating a parcel label from a crm lead.

Note that in the project.task case, the algorithm is not improved.