### PR TITLE
Fix name errors when using cooperative campaign late optin wizard

### DIFF
--- a/commown_cooperative_campaign/models/discount.py
+++ b/commown_cooperative_campaign/models/discount.py
@@ -10,7 +10,8 @@ import iso8601
 import pytz
 import requests
 
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 

--- a/commown_cooperative_campaign/tests/test_coupon.py
+++ b/commown_cooperative_campaign/tests/test_coupon.py
@@ -181,3 +181,24 @@ class CouponTestTC(SavepointCase):
         with requests_mock.Mocker() as rm:
             rm.post(self.paths["opt-in"], json=optin)
             wizard.late_optin()
+
+    def test_wizard_late_optin_error(self):
+        wizard = self.env["coupon.late.optin.wizard"].create(
+            {
+                "coupon_id": self.coupon.id,
+            }
+        )
+
+        with requests_mock.Mocker() as rm:
+            rm.post(
+                self.paths["opt-in"],
+                status_code=422,
+                json={"detail": "Already opt-in"},
+            )
+            with self.assertRaises(UserError) as err:
+                wizard.late_optin()
+
+        self.assertEqual(
+            err.exception.name,
+            "Already opt-in (may not be visible if before the campaign start)",
+        )


### PR DESCRIPTION
Add tests to cover this use case too.