### PR TITLE
All rental products' AR leads must be related to their contracts

### DIFF
--- a/commown_lead_risk_analysis/models/sale_order.py
+++ b/commown_lead_risk_analysis/models/sale_order.py
@@ -58,7 +58,7 @@ class SaleOrder(models.Model):
         contract_lines = self.env["contract.line"].search(
             [
                 ("sale_order_line_id.order_id", "=", self.id),
-                ("sale_order_line_id.product_id.is_contract", "=", True),
+                ("sale_order_line_id.product_id.is_rental", "=", True),
                 ("sale_order_line_id.product_id.followup_sales_team_id", "!=", False),
             ]
         )
@@ -80,12 +80,12 @@ class SaleOrder(models.Model):
                 self.name,
             )
 
-        # Also create a lead for non contract products with a followup team
+        # Also create a lead for non rental products with a followup team
         count = 0
         for so_line in self.order_line:
             product = so_line.product_id
             team = product.followup_sales_team_id
-            if team and not product.is_contract:
+            if team and not product.is_rental:
                 for _num in range(int(so_line.product_uom_qty)):
                     count += 1
                     name = self.risk_analysis_lead_title(so_line, secondary_index=count)

--- a/product_rental/tests/common.py
+++ b/product_rental/tests/common.py
@@ -192,7 +192,7 @@ class RentalSaleOrderMixin:
         kwargs.setdefault("is_rental", True)
         kwargs.setdefault("type", "service")
         kwargs.setdefault("taxes_id", False)
-        kwargs["is_contract"] = bool(kwargs["property_contract_template_id"])
+        kwargs["is_contract"] = bool(kwargs.get("property_contract_template_id"))
         result = self.env["product.product"].create(kwargs)
         # Otherwise is_contract may be wrong (in one of commown_devices tests):
         result.env.cache.invalidate()


### PR DESCRIPTION
Before the patch, only the product with a contract template were.