### PR TITLE
Unhide tags on leads

### DIFF
--- a/commown_lead_risk_analysis/views/crm_lead.xml
+++ b/commown_lead_risk_analysis/views/crm_lead.xml
@@ -29,7 +29,7 @@
             <attribute name="attrs">{'invisible': [('used_for_risk_analysis', '=', True)]}</attribute>
           </xpath>
 
-          <xpath expr="//field[@name='priority']/ancestor::group[1]" position="attributes">
+          <xpath expr="//field[@name='priority']" position="attributes">
             <attribute name="attrs">{'invisible': [('used_for_risk_analysis', '=', True)]}</attribute>
           </xpath>
 


### PR DESCRIPTION
The entire group was hidden although only priority is problematic here (because there are other evaluation-like fields).
So we only hide the priority field instead of the entire group.