### PR TITLE
12.0 Unhide german product website categories but Alle Produkte

### DIFF
--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -130,11 +130,8 @@
   <!-- Language related hacks START -->
 
   <template id="products_categories" inherit_id="website_sale.products_categories">
-    <xpath expr="//div[@id='products_grid_before']/ul[hasclass('nav')]/li[1]" position="attributes">
-      <attribute name="t-if">request.lang == 'fr_FR'</attribute>
-    </xpath>
     <xpath expr="//t[@t-call='website_sale.categories_recursive']" position="attributes">
-      <attribute name="t-if">(request.lang == 'fr_FR' and c != env.ref('commown.categ_de')) or request.env.user.has_group('website.group_website_publisher')</attribute>
+      <attribute name="t-if">c != env.ref('commown.categ_de')</attribute>
     </xpath>
   </template>
 


### PR DESCRIPTION
The Alle Produkte category aims at tagging products as available in Germany. It is hidden on the website.