### PR TITLE
Fix sale order name no more updatable through the web UI

### DIFF
--- a/website_sale_b2b/models/sale_order.py
+++ b/website_sale_b2b/models/sale_order.py
@@ -51,7 +51,11 @@ class SaleOrder(models.Model):
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    name = fields.Text(compute="_recompute_name", store=True)
+    name = fields.Text(
+        compute="_recompute_name",
+        inverse=lambda self: None,  # Make it updatable through the UI despite compute
+        store=True,
+    )
 
     def display_rental_price(self, amount=None):
         """Format current line's product rental price in the order partner's language


### PR DESCRIPTION
The sale order name field was set as computed so was no more editable using the web UI. Adding an inverse function that does nothing fixes it.

The alternative (using onchange + override create and update/write) is much more verbose and more difficult to maintain, so I chose this hack.