### PR TITLE
Fix erroneous user error on VAT even when the VAT code is correct

### DIFF
--- a/website_sale_b2b/controllers/main.py
+++ b/website_sale_b2b/controllers/main.py
@@ -109,6 +109,7 @@ class WebsiteSaleB2B(WebsiteSale):
         env = http.request.env
         if (
             http.request.website == env.ref("website_sale_b2b.b2b_website")
+            and not data.get("vat")
             and data.get("country_id")
             and data.get("country_id") != str(env.user.company_id.country_id.id)
         ):


### PR DESCRIPTION
The missing condition for raising was... "is vat empty?", which was crucial of course. But as it is in a controller and testing controllers in odoo is not that easy, it was (and is still) not tested.