### PR TITLE
Fix delivery address cannot be submitted on the B2B website

### DIFF
--- a/commown/views/address_template.xml
+++ b/commown/views/address_template.xml
@@ -59,7 +59,7 @@
          t-value="env.user.website_id == env.ref('website_sale_b2b.b2b_website')" />
       <input type="hidden"
              name="field_required"
-             t-att-value="'firstname,lastname,street,phone,zip,city,country_id' + (',company_name' if is_b2b else '')" />
+             t-att-value="'firstname,lastname,street,phone,zip,city,country_id' + (',company_name' if (is_b2b and mode[1] == 'billing') else '')" />
     </xpath>
 
   </template>


### PR DESCRIPTION
The company_name field was considered mandatory on B2B delivery address form, while it should only be on the B2B billing address form.