### PR TITLE
Fix delivery address portal form submission when a B2B partner is abroad

### DIFF
--- a/website_sale_b2b/controllers/main.py
+++ b/website_sale_b2b/controllers/main.py
@@ -109,6 +109,7 @@ class WebsiteSaleB2B(WebsiteSale):
         env = http.request.env
         if (
             http.request.website == env.ref("website_sale_b2b.b2b_website")
+            and mode[1] == "billing"
             and not data.get("vat")
             and data.get("country_id")
             and data.get("country_id") != str(env.user.company_id.country_id.id)


### PR DESCRIPTION
The VAT field was handled as mandatory by the controller in that case although it is not present in the form (which is OK). The fix is to consider the VAT as mandatory only when the address is a billing address.