### PR TITLE
Fix incorrect quantity in contract when orphan accessory quantity is > 1

### DIFF
--- a/product_rental/models/sale_order_line.py
+++ b/product_rental/models/sale_order_line.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from datetime import date
 
 from odoo import api, models
@@ -112,8 +113,11 @@ class ProductRentalSaleOrderLine(models.Model):
 def _rental_products(contract_descr):
     "Helper function to prepare data required for contract line generation"
     so_line = contract_descr["so_line"]
-    _acs = contract_descr["accessories"]
-    __acs = [(p, l, 1) for (p, l) in set(_acs)]
+
+    _acs = defaultdict(int)
+    for items in contract_descr["accessories"]:
+        _acs[items] += 1
+    __acs = [(p, l, q) for ((p, l), q) in _acs.items()]
 
     return {
         CONTRACT_PROD_MARKER: [(so_line.product_id, so_line, 1)],

--- a/product_rental/tests/common.py
+++ b/product_rental/tests/common.py
@@ -103,7 +103,16 @@ class RentalSaleOrderMixin:
             4,
             contract_line_ids=[
                 self._contract_line(
-                    1, "1 month of ##PRODUCT##", tax, specific_price=0.0
+                    1,
+                    "1 month of ##PRODUCT##",
+                    tax,
+                    specific_price=0.0,
+                ),
+                self._contract_line(
+                    2,
+                    "1 month of ##ACCESSORY##",
+                    tax,
+                    specific_price=0.0,
                 ),
             ],
         )
@@ -130,7 +139,7 @@ class RentalSaleOrderMixin:
             rental_price=15.0,
             property_contract_template_id=False,
         )
-        oline_a2 = self._oline(a2, product_uom_qty=2)
+        oline_a2 = self._oline(a2, product_uom_qty=4)
 
         a3 = self._create_rental_product(
             name="keyboard",

--- a/product_rental/tests/test_sale_order.py
+++ b/product_rental/tests/test_sale_order.py
@@ -122,16 +122,16 @@ class SaleOrderContractGenerationTC(RentalSaleOrderTC):
             },
         )
 
-        self.assert_rounded_equals(i5.amount_total, 20.0)
-        self.assert_rounded_equals(i5.amount_untaxed, 16.67)
+        self.assert_rounded_equals(i5.amount_total, 50.0)
+        self.assert_rounded_equals(i5.amount_untaxed, 41.67)
 
         self.assert_contract_lines_attributes_equal(
             c5,
             {
-                "name": ["1 month of FP2"],
-                "price_unit": [20.0],
-                "quantity": [1],
-                "sale_order_line_id.product_id.name": ["FP2"],
+                "name": ["1 month of FP2", "1 month of screen"],
+                "price_unit": [20.0, 15.0],
+                "quantity": [1, 2],
+                "sale_order_line_id.product_id.name": ["FP2", "screen"],
                 "analytic_account_id.name": [c5.name],
                 "analytic_account_id.partner_id": c5.partner_id,
             },
@@ -227,16 +227,16 @@ class SaleOrderContractGenerationTC(RentalSaleOrderTC):
             },
         )
 
-        self.assert_rounded_equals(i5.amount_total, 20.0)
-        self.assert_rounded_equals(i5.amount_untaxed, 16.67)
+        self.assert_rounded_equals(i5.amount_total, 50.0)
+        self.assert_rounded_equals(i5.amount_untaxed, 41.67)
 
         self.assert_contract_lines_attributes_equal(
             c5,
             {
-                "name": ["1 month of FP2"],
-                "price_unit": [20.0],
-                "quantity": [1],
-                "sale_order_line_id.product_id.name": ["FP2"],
+                "name": ["1 month of FP2", "1 month of screen"],
+                "price_unit": [20.0, 15.0],
+                "quantity": [1, 2],
+                "sale_order_line_id.product_id.name": ["FP2", "screen"],
             },
         )
 


### PR DESCRIPTION
When a sale order confirmation generates at least a contract, accessories are distributed in generated contracts, one per contract until last contract, which receives all orphan accessories. This commit fixes the quantity of this orphan accessories when there is more than one orphan of the same accessory product.