### PR TITLE
Fix a crash when generating the last invoice of a contract

### DIFF
--- a/commown/models/contract.py
+++ b/commown/models/contract.py
@@ -78,7 +78,9 @@ class Contract(models.Model):
         """Insert custom payment transaction label into the context
         before executing the standard payment process."""
         if self.transaction_label:
-            last_date_invoiced = self.recurring_next_date - relativedelta(days=1)
+            last_date_invoiced = max(
+                self.contract_line_ids.mapped("last_date_invoiced")
+            ) + relativedelta(days=1)
             label = self._format_transaction_label(invoice, last_date_invoiced)
             _logger.debug("Bank label for invoice %s: %s", invoice.number, label)
             self = self.with_context(slimpay_payin_label=label)

--- a/commown/tests/test_contract.py
+++ b/commown/tests/test_contract.py
@@ -1,3 +1,4 @@
+from dateutil.relativedelta import relativedelta
 from mock import patch
 
 from odoo.addons.contract.tests.test_contract import TestContractBase
@@ -41,6 +42,11 @@ class ContractPaymentTC(TestContractBase):
             self.assertEqual(label, invoice.number)
 
     def test_custom_payin_label(self):
+        # Make this the last invoice of the contract
+        # (see project task #15112: crash on last invoice generation)
+        for cline in self.contract.contract_line_ids:
+            cline.date_end = cline.next_period_date_end - relativedelta(days=1)
+
         self.contract.write(
             {
                 "transaction_label": "Invoice #START# - #END# (#INV#)",


### PR DESCRIPTION
When the contract end date is not exactly an invoice generation date, the previous implementation of the payin bank label generation was crashing badly, because it was using the recurring next date of the contract, which becomes falsy at the end of the contract.

It is now using the contract lines' last invoiced date, which is correctly set by the contract module.