### PR TITLE
Re-fix the crash when generating the last invoice of an auto-pay contract

### DIFF
--- a/commown/models/contract.py
+++ b/commown/models/contract.py
@@ -1,7 +1,5 @@
 import logging
 
-from dateutil.relativedelta import relativedelta
-
 from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
@@ -79,8 +77,8 @@ class Contract(models.Model):
         before executing the standard payment process."""
         if self.transaction_label:
             last_date_invoiced = max(
-                self.contract_line_ids.mapped("last_date_invoiced")
-            ) + relativedelta(days=1)
+                invoice.mapped("invoice_line_ids.contract_line_id.last_date_invoiced")
+            )
             label = self._format_transaction_label(invoice, last_date_invoiced)
             _logger.debug("Bank label for invoice %s: %s", invoice.number, label)
             self = self.with_context(slimpay_payin_label=label)

--- a/commown/tests/test_contract.py
+++ b/commown/tests/test_contract.py
@@ -58,7 +58,7 @@ class ContractPaymentTC(TestContractBase):
         ) as pay:
             invoice = self.contract.recurring_create_invoice()
             label = pay.call_args[0][-1]
-            expected_label = "Invoice 01/15/2018 - 02/14/2018 (%s)" % invoice.number
+            expected_label = "Invoice 01/15/2018 - 02/13/2018 (%s)" % invoice.number
             self.assertEqual(label, expected_label)
 
     def test_amount(self):


### PR DESCRIPTION
Previous implementation shifted the bank label last date by one day. This was due to a bad interpretation of the test data: a date_end set on the contract line of the test was trimming the last invoiced date.

The new implementation now uses the contract line last invoiced date, which is dedicated to the purpose. It uses the invoice lines to get to the contract lines to avoid wrong usage of non-invoiced contract lines (for instance because of a zero-computed quantity or such).