### PR TITLE
Try to group bought product and their options in the same contract

### DIFF
--- a/product_rental/models/sale_order.py
+++ b/product_rental/models/sale_order.py
@@ -89,6 +89,7 @@ class ProductRentalSaleOrder(models.Model):
                 contract_descr["so_line"].name,
                 contract_num,
             )
+
             _logger.debug(
                 "Unassigned accessories: %s",
                 ", ".join(
@@ -96,8 +97,15 @@ class ProductRentalSaleOrder(models.Model):
                     for (a, so_lines) in bought_accessories.items()
                 ),
             )
+
+            main_product = contract_descr["main"]
+            main_accessories = (
+                main_product.accessory_product_ids
+                | main_product.optional_product_ids.mapped("product_variant_ids")
+            )
+
             for accessory, so_lines in list(bought_accessories.items()):
-                if accessory in contract_descr["main"].accessory_product_ids:
+                if accessory in main_accessories:
                     contract_descr["accessories"].append((accessory, so_lines.pop(0)))
                     _logger.debug("> Assigned accessory %s", accessory.name)
                     if len(bought_accessories[accessory]) == 0:

--- a/product_rental/tests/common.py
+++ b/product_rental/tests/common.py
@@ -88,6 +88,7 @@ class RentalSaleOrderMixin:
                 self._contract_line(
                     1, "1 month of ##PRODUCT##", tax, specific_price=0.0
                 ),
+                self._contract_line(2, "1 month of ##ACCESSORY##", tax),
             ],
         )
         product3 = self._create_rental_product(
@@ -160,6 +161,16 @@ class RentalSaleOrderMixin:
         product1.accessory_product_ids |= a1
         product2.accessory_product_ids |= a2 + a3 + a4
 
+        # Optional products
+        o1 = self._create_rental_product(
+            name="serenity level services",
+            list_price=3.0,
+            rental_price=6.0,
+            property_contract_template_id=False,
+        )
+        oline_o1 = self._oline(o1)
+        product3.optional_product_ids |= o1.product_tmpl_id
+
         return env["sale.order"].create(
             {
                 "partner_id": partner.id,
@@ -174,6 +185,7 @@ class RentalSaleOrderMixin:
                     oline_a2,
                     oline_a3,
                     oline_a4,
+                    oline_o1,
                 ],
             }
         )

--- a/product_rental/tests/test_sale_order.py
+++ b/product_rental/tests/test_sale_order.py
@@ -107,16 +107,19 @@ class SaleOrderContractGenerationTC(RentalSaleOrderTC):
             },
         )
 
-        self.assert_rounded_equals(i4.amount_total, 10.0)
-        self.assert_rounded_equals(i4.amount_untaxed, 8.33)
+        self.assert_rounded_equals(i4.amount_total, 16.0)
+        self.assert_rounded_equals(i4.amount_untaxed, 13.33)
 
         self.assert_contract_lines_attributes_equal(
             c4,
             {
-                "name": ["1 month of GS Headset"],
-                "price_unit": [10.0],
-                "quantity": [1],
-                "sale_order_line_id.product_id.name": ["GS Headset"],
+                "name": ["1 month of GS Headset", "1 month of serenity level services"],
+                "price_unit": [10.0, 6.0],
+                "quantity": [1, 1],
+                "sale_order_line_id.product_id.name": [
+                    "GS Headset",
+                    "serenity level services",
+                ],
                 "analytic_account_id.name": [c4.name],
                 "analytic_account_id.partner_id": c4.partner_id,
             },
@@ -214,16 +217,19 @@ class SaleOrderContractGenerationTC(RentalSaleOrderTC):
             },
         )
 
-        self.assert_rounded_equals(i4.amount_total, 10.0)
-        self.assert_rounded_equals(i4.amount_untaxed, 8.33)
+        self.assert_rounded_equals(i4.amount_total, 16.0)
+        self.assert_rounded_equals(i4.amount_untaxed, 13.33)
 
         self.assert_contract_lines_attributes_equal(
             c4,
             {
-                "name": ["1 month of GS Headset"],
-                "price_unit": [10.0],
-                "quantity": [1],
-                "sale_order_line_id.product_id.name": ["GS Headset"],
+                "name": ["1 month of GS Headset", "1 month of serenity level services"],
+                "price_unit": [10.0, 6.0],
+                "quantity": [1, 1],
+                "sale_order_line_id.product_id.name": [
+                    "GS Headset",
+                    "serenity level services",
+                ],
             },
         )
 

--- a/product_rental/tests/test_website.py
+++ b/product_rental/tests/test_website.py
@@ -55,6 +55,7 @@ class WebsiteTC(RentalSaleOrderTC):
                 "screen (deposit)",
                 "keyboard (deposit)",
                 "keyboard deluxe (deposit)",
+                "serenity level services (deposit)",
             ],
         )
 


### PR DESCRIPTION
This was already done for accessory product, so add optional products to the list of products which may be grouped with the main products (those with a contract template).