### PR TITLE
Fix SMS reminder for support

### DIFF
--- a/commown/models/project_task.py
+++ b/commown/models/project_task.py
@@ -53,8 +53,11 @@ class ProjectTask(models.Model):
             # Send the SMS
             template = self.env.ref("commown.sms_template_issue_reminder")
             layout = "commown_payment_slimpay_issue.message_nowrap_template"
-            self.with_context(custom_layout=layout).message_post_with_template(
-                template.id, message_type="comment"
+            self.with_context(
+                custom_layout=layout, lang=self.partner_id.lang
+            ).message_post_with_template(
+                template.id,
+                message_type="comment",
             )
 
             # Put followers back

--- a/commown/tests/test_project_task.py
+++ b/commown/tests/test_project_task.py
@@ -120,7 +120,7 @@ class ProjectTaskActionTC(TransactionCase):
     def assertIsStageChangeMessage(self, message):
         self.assertEqual(message.subtype_id, self.env.ref("project.mt_task_new"))
 
-    def _test_send_reminders(self):
+    def test_send_reminders(self):
         """A reminder mail to followers and SMS to partner must be sent
         when task is put in the dedicated column.
         """
@@ -140,7 +140,7 @@ class ProjectTaskActionTC(TransactionCase):
         )
         self.assertIsReminderEmail(self.task.message_ids[2])
 
-    def _test_send_reminder_no_sms(self):
+    def test_send_reminder_no_sms(self):
         """A reminder SMS must not be sent when a non-employee message
         (interpreted as a message from the partner) has already been sent.
         """
@@ -160,7 +160,7 @@ class ProjectTaskActionTC(TransactionCase):
         self.assertIsStageChangeMessage(self.task.message_ids[0])
         self.assertIsReminderEmail(self.task.message_ids[1])
 
-    def _test_move_task_after_expiry(self):
+    def test_move_task_after_expiry(self):
         """After 10 days spent in the reminder stage, crontab should
         automatically move the task into the 'end-ok' stage."""
 
@@ -263,7 +263,7 @@ class ProjectTaskActionTC(TransactionCase):
             self.task.stage_id, self.stage_pending, self.task.stage_id.name
         )
 
-    def _test_payment_task_process_automatically(self):
+    def test_payment_task_process_automatically(self):
         inv = (
             self.env["account.invoice"]
             .search([])

--- a/commown/views/project_task.xml
+++ b/commown/views/project_task.xml
@@ -76,31 +76,7 @@ record.message_post_with_template(email_template)
     <field name="model_id" ref="project.model_project_task"/>
     <field name="sequence">10</field>
     <field name="state">code</field>
-    <field name="code"><![CDATA[
-if record.user_id:
-    record = record.sudo(record.user_id)
-if record.partner_id.mobile or record.partner_id.phone:
-    employees = env.ref('base.group_user')
-    if not any(m for m in record.message_ids if employees not in m.author_id.mapped('user_ids.groups_id')):
-        template = env.ref('commown.sms_template_issue_reminder')
-        record = record.with_context({
-            "custom_layout": "commown_payment_slimpay_issue.message_nowrap_template",
-            "lang": record.partner_id.lang,
-        })
-        # Temporarily remove followers
-        _data = [f.copy_data()[0] for f in record.message_follower_ids]
-        record.sudo().message_follower_ids.unlink()
-
-        # Send the SMS
-        record.message_post_with_template(template.id, message_type='comment')
-
-        # Put followers back
-        current_followers = record.mapped('message_follower_ids.partner_id')
-        for data in _data:
-            if data['partner_id'] not in current_followers.ids:
-                env['mail.followers'].create(data)
-]]>
-    </field>
+    <field name="code">record.send_sms_reminder()</field>
   </record>
 
   <!-- Automatic action to execute reminder email and SMS send action


### PR DESCRIPTION
The `action_send_issue_reminder_sms` action code was different from the project.task `send_sms_reminder` method and the tests were commented-out (probably since the v12 upgrade). The code difference matters as the commented-out tests were not green, and they are now.

Note the SMS language has been forced in the context to the project.task partner, as it was in the action's code.