### PR TITLE
Add an index on account_move_line.full_reconcile_id to speed-up reconcilation dramatically

### DIFF
--- a/commown/models/account_move_line.py
+++ b/commown/models/account_move_line.py
@@ -1,9 +1,11 @@
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class CommownAccountMoveLine(models.Model):
 
     _inherit = "account.move.line"
+
+    full_reconcile_id = fields.Many2one(index=True)
 
     @api.multi
     def step_workflow(self):


### PR DESCRIPTION
This will have a negative performance impact on insertion of course, but we do not massively insert account_move_line lines so it should not be a problem for us.