### PR TITLE
Fix fees-related invoices reconciliation error

### DIFF
--- a/rental_fees/views/rental_fees_computation.xml
+++ b/rental_fees/views/rental_fees_computation.xml
@@ -12,7 +12,6 @@
         <field name="product_template_id" invisible="True"/>
         <field name="fees" string="Fees until date"/>
         <field name="until_date" string="Date"/>
-        <field name="invoiced_amount" sum="1"/>
         <field name="state"/>
       </tree>
     </field>


### PR DESCRIPTION
Remove the invoiced_amount fees computation computed field, as it is not always up to date.

Better rely on the past invoices' amount to generate current computation invoice.