### PR TITLE
Make website_description readonly and hide website-publish button to non french users

### DIFF
--- a/commown/models/product_template.py
+++ b/commown/models/product_template.py
@@ -13,3 +13,11 @@ class SupportedProductTemplate(models.Model):
     )
 
     sale_line_warn_msg = fields.Text(translate=True)
+
+    is_user_lang_fr = fields.Boolean(
+        compute="_compute_is_user_lang_fr",
+        store=False,
+    )
+
+    def _compute_is_user_lang_fr(self):
+        self.update({"is_user_lang_fr": self.env.user.lang == "fr_FR"})

--- a/commown/views/product_template.xml
+++ b/commown/views/product_template.xml
@@ -17,8 +17,14 @@
 
         <xpath expr="//page[@name='website']" position="inside">
             <group name="website">
-              <field name="website_description"/>
+              <field name="is_user_lang_fr" invisible="1"/>
+              <field name="website_description"
+                     attrs="{'readonly': [('is_user_lang_fr', '=', False)]}"/>
             </group>
+        </xpath>
+
+        <xpath expr="//button[@name='website_publish_button']" position="attributes">
+          <attribute name="attrs">{'invisible': ['|', ('sale_ok','=',False), ('is_user_lang_fr', '=', False)]}</attribute>
         </xpath>
 
       </field>


### PR DESCRIPTION
When the user has not the 'fr_FR' lang set in its preferences, editing the website description is really buggy on the backend side. See detailed explanation here: https://shop.commown.coop/web#id=15691&action=315&active_id=10&model=project.task&view_type=form&menu_id=233.