### PR TITLE
Reset payment date preferences of partners which payment token is reset

### DIFF
--- a/commown/models/res_partner.py
+++ b/commown/models/res_partner.py
@@ -217,3 +217,14 @@ class CommownPartner(models.Model):
         else:
             res["email"] = res["login"] = partner.email or ""
         return res
+
+    def reset_payment_token(self):
+        "Force the reset on payment preferences on payment token reset"
+        super().reset_payment_token()
+        self.update(
+            {
+                "invoice_merge_recurring_rule_type": False,
+                "invoice_merge_recurring_interval": False,
+                "invoice_merge_next_date": False,
+            }
+        )

--- a/payment_token_uniquify/models/obsolescence_action.py
+++ b/payment_token_uniquify/models/obsolescence_action.py
@@ -47,4 +47,4 @@ class PaymentTokenUniquifyObsolescenceAction(models.Model):
         #   web UI users that the partner has no usable token anymore
         for partner in obsolete_tokens.mapped("partner_id"):
             if partner.payment_token_id in obsolete_tokens:
-                partner.payment_token_id = False
+                partner.reset_payment_token()

--- a/payment_token_uniquify/models/res_partner.py
+++ b/payment_token_uniquify/models/res_partner.py
@@ -30,3 +30,7 @@ class ResPartner(models.Model):
                     ("id", "!=", newer_token.id),
                 ]
             )
+
+    def reset_payment_token(self):
+        "Set payment_token_id to False, making it possible to override this behaviour"
+        self.update({"payment_token_id": False})


### PR DESCRIPTION
This way, if such a partner sign a new mandate in the future, the payment date will be correctly set instead of preserving an old, insignificant one.