### PR TITLE
Specifiy where to look for lots and product when creating return picking

### DIFF
--- a/commown_devices/models/contract.py
+++ b/commown_devices/models/contract.py
@@ -95,8 +95,8 @@ class Contract(models.Model):
         return self._create_picking(
             lots,
             products,
-            self.env.ref("stock.stock_location_locations_partner"),
-            self.env.ref("stock.stock_location_locations_partner"),
+            self.partner_id.get_or_create_customer_location(),
+            self.partner_id.get_or_create_customer_location(),
             dest_location,
             origin=origin,
             date=date,


### PR DESCRIPTION
Looking for product in location that where child of the parent location of all partner wasn't specific enough and caused accessories to be received from another parnet location. This commit also modify the location were lot are searched even if with the serial number it is not necessary.