### PR TITLE
Fix incorrect price for fees compensation

### DIFF
--- a/rental_fees/tests/common.py
+++ b/rental_fees/tests/common.py
@@ -107,6 +107,17 @@ class RentalFeesTC(DeviceAsAServiceTC):
             for ml in move.move_line_ids:
                 _set_date(ml, po.date_planned, "date")
 
+        # Create the invoice as the web UI would:
+        action = po.with_context(create_bill=True).action_view_invoice()
+        created_model = self.env["account.invoice"].with_context(action["context"])
+        fields = created_model.fields_get()
+        defaults = created_model.default_get(fields.keys())
+        values = defaults.copy()
+        result = created_model.onchange(values, [], created_model._onchange_spec())
+        values.update(result["value"])
+        values = self.env["account.invoice"]._convert_to_write(values)
+        self.env["account.invoice"].create(values)
+
         return po
 
     def current_quant(self, device):

--- a/rental_fees/tests/test_rental_fees_definition.py
+++ b/rental_fees/tests/test_rental_fees_definition.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from odoo.models import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 from .common import RentalFeesTC
 
@@ -92,6 +92,17 @@ class RentalFeesDefinitionTC(RentalFeesTC):
         self.assertEqual(
             self.fees_def.prices(device),
             {"standard": 500.0, "purchase": 200.0},
+        )
+
+        # Also check the error case (no invoice found for device)
+        self.po.invoice_ids.action_invoice_cancel()
+
+        with self.assertRaises(UserError) as err:
+            self.fees_def.prices(device)
+        self.assertEqual(
+            err.exception.name,
+            "No price for device N/S 1: its PO line has no invoice, see %s"
+            % self.po.name,
         )
 
     def test_scrapped_devices(self):


### PR DESCRIPTION
We now use the invoiced price of the device, not the purchase order price, which is indicative and may even be 0.