### PR TITLE
Check redirections befor checking authorisations.

### DIFF
--- a/commown/models/__init__.py
+++ b/commown/models/__init__.py
@@ -5,6 +5,7 @@ from . import account_partial_reconcile
 from . import contract
 from . import crm_lead
 from . import coupon
+from . import ir_http
 from . import mass_reconcile
 from . import payment
 from . import payment_token_obsolescence_action

--- a/commown/models/ir_http.py
+++ b/commown/models/ir_http.py
@@ -1,0 +1,18 @@
+from odoo import models
+from odoo.http import request
+
+from odoo.addons.portal.controllers.portal import _build_url_w_params
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = "ir.http"
+
+    @classmethod
+    def _handle_exception(cls, exc):
+        redirect = cls._serve_redirect()
+        if redirect:
+            return request.redirect(
+                _build_url_w_params(redirect.url_to, request.params), code=redirect.type
+            )
+
+        return super(IrHttp, cls)._handle_exception(exc)

--- a/commown/tests/__init__.py
+++ b/commown/tests/__init__.py
@@ -3,6 +3,7 @@ from . import test_contract
 from . import test_controllers
 from . import test_crm_lead
 from . import test_customer_portal
+from . import test_ir_http
 from . import test_payment
 from . import test_payment_token
 from . import test_project_task

--- a/commown/tests/test_ir_http.py
+++ b/commown/tests/test_ir_http.py
@@ -1,0 +1,29 @@
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse
+
+from odoo.service import wsgi_server
+from odoo.tests.common import HttpCase
+
+
+class IrHttpTC(HttpCase):
+    def setUp(self):
+        super().setUp()
+        self.werkzeug_environ = {"REMOTE_ADDR": "127.0.0.1"}
+
+    def test_redirect(self):
+        test_client = Client(wsgi_server.application, BaseResponse)
+        pt1 = self.env.ref("product.product_delivery_01_product_template")
+        pt2 = self.env.ref("product.product_delivery_02_product_template")
+
+        pt1.website_published = False
+
+        # Check Prerequisite
+        response = test_client.get(pt1.website_url, follow_redirects=False)
+        self.assertEqual(response.status_code, 403)
+
+        self.env["website.redirect"].create(
+            {"type": "302", "url_from": pt1.website_url, "url_to": pt2.website_url}
+        )
+        response = test_client.get(pt1.website_url, follow_redirects=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.headers["Location"].endswith(pt2.website_url))


### PR DESCRIPTION
This allow public user to get redirected even if the first product they were looking for was unpulbished