### PR TITLE
Fix a crash when creating a contract-line specific discount

### DIFF
--- a/contract_variable_discount/views/contract.xml
+++ b/contract_variable_discount/views/contract.xml
@@ -46,7 +46,8 @@
       <group name="note_invoicing_mode" position="before">
         <group name="Variable discount">
           <field name="inherited_discount_line_ids"/>
-          <field name="specific_discount_line_ids"/>
+          <field name="specific_discount_line_ids"
+                 context="{'default_contract_line_id': id}"/>
           <field name="contract_template_line_id" invisible="1"/>
         </group>
       </group>

--- a/contract_variable_discount/views/discount.xml
+++ b/contract_variable_discount/views/discount.xml
@@ -42,6 +42,7 @@
       <form string="Contract discount line">
         <group>
           <group name="general" string="General">
+            <field name="contract_line_id" invisible="1"/>
             <field name="name"/>
             <field name="condition"/>
             <field name="replace_discount_line_id_domain" invisible="1"/>


### PR DESCRIPTION
More precisely, the crash occurs when clicking in the 'Replace discount line' field of the contract.discount.line creation form.

The crash was caused by the domain being empty (false in fact), because the _compute_replace_discount_line_id_domain method was not called on creation. To trigger its call, we set default_contract_line_id in the context of the specific_discount_line_ids field so that the contract_line_id changes when the discount line is created.