### PR TITLE
Don't crash on self troubleshooting pages when user has no phone or e…

### DIFF
--- a/commown_self_troubleshooting/data/common_steps.xml
+++ b/commown_self_troubleshooting/data/common_steps.xml
@@ -116,7 +116,7 @@
 
     <template id="step-ship-module">
       <t t-set="partner" t-value="env.user.partner_id" />
-      <t t-set="delivery" t-value="partner.colissimo_delivery_data()" />
+      <t t-set="delivery" t-value="partner.colissimo_delivery_data(raise_on_error=False)" />
       <t t-set="_countries" t-value="env['res.country'].search([('code', 'in', ('FR', 'BE', delivery['countryCode']))])" />
       <t t-set="countries" t-value="[(c.code, c.name) for c in _countries]" />
       <div t-attf-id="step-{{ step }}" class="tab-pane" role="tabpanel" t-attf-aria-labelledby="step-{{ step }}">

--- a/commown_shipping/models/colissimo_utils.py
+++ b/commown_shipping/models/colissimo_utils.py
@@ -32,13 +32,13 @@ def normalize_phone(phone_number, country_code):
     return ""
 
 
-def delivery_data(partner):
+def delivery_data(partner, raise_on_error=True):
     """Return delivery data for given partner, taking into account:
 
     - that mobile phone numbers may be found in partner.phone instead
       of partner.mobile: put value into mobile if pertinent
     - the address lines must not be too long (35 characters was the limit on
-      coliship): in such a case, raise ValueError
+      coliship): in such a case, raise ValueError unless raise_on_error is False
     - at least one phone number is required to ease delivery
     - an email is required to get a delivery notification
 
@@ -69,12 +69,14 @@ def delivery_data(partner):
     if partner.parent_id and partner.parent_id.is_company:
         partner_data["companyName"] = partner.parent_id.name
 
-    if not (partner_data["phoneNumber"] or partner_data["mobileNumber"]):
+    if raise_on_error and not (
+        partner_data["phoneNumber"] or partner_data["mobileNumber"]
+    ):
         raise ColissimoError(
             _("A phone number is required to generate a Colissimo label!")
         )
 
-    if not partner_data["email"]:
+    if raise_on_error and not partner_data["email"]:
         raise ColissimoError(_("An email is required to generate a Colissimo label!"))
 
     return partner_data

--- a/commown_shipping/models/res_partner.py
+++ b/commown_shipping/models/res_partner.py
@@ -25,9 +25,9 @@ class ResPartner(models.Model):
     ]
 
     @api.multi
-    def colissimo_delivery_data(self):
+    def colissimo_delivery_data(self, raise_on_error=True):
         self.ensure_one()
-        return delivery_data(self)
+        return delivery_data(self, raise_on_error=raise_on_error)
 
     @classmethod
     def validate_street_lines(cls, data, error, error_message):

--- a/commown_shipping/tests/test_res_partner.py
+++ b/commown_shipping/tests/test_res_partner.py
@@ -1,9 +1,15 @@
+from contextlib import contextmanager
+
 from psycopg2 import IntegrityError
 
 from odoo.tests.common import TransactionCase
 
+from ..models.colissimo_utils import ColissimoError
+
 
 class ResPartnerTC(TransactionCase):
+    "Tests for partner methods implemented in present module"
+
     def test_street_length_low_level(self):
         with self.assertRaises(IntegrityError) as err:
             partner = self.env["res.partner"].create({"name": "T", "street": "a" * 36})
@@ -28,3 +34,67 @@ class ResPartnerTC(TransactionCase):
             messages,
             ["Address lines' length is limited to 35. Please fix."],
         )
+
+    def test_colissimo_delivery_data(self):
+        @contextmanager
+        def emptied_fields(partner, *fields):
+            old_values = {}
+            for field in fields:
+                old_values[field] = getattr(partner, field)
+                setattr(partner, field, False)
+            yield
+            for field in fields:
+                setattr(partner, field, old_values[field])
+
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": "Firsttest",
+                "lastname": "Lasttest",
+                "street": "8A rue Schertz",
+                "zip": "67200",
+                "city": "Strasbourg",
+                "country_id": self.env.ref("base.fr").id,
+                "mobile": "060101010101",
+                "phone": "030101010101",
+                "email": "contact@commown.coop",
+            }
+        )
+
+        expected = {
+            "city": "Strasbourg",
+            "countryCode": "FR",
+            "email": "contact@commown.coop",
+            "firstName": "Firsttest",
+            "lastName": "Lasttest",
+            "line2": "8A rue Schertz",
+            "mobileNumber": "60101010101",
+            "phoneNumber": "30101010101",
+            "zipCode": "67200",
+        }
+        self.assertEqual(partner.colissimo_delivery_data(), expected)
+
+        # Email is mandatory...
+        with emptied_fields(partner, "email"):
+            with self.assertRaises(ColissimoError) as err:
+                partner.colissimo_delivery_data()
+        self.assertEqual(
+            err.exception.args, ("An email is required to generate a Colissimo label!",)
+        )
+
+        # ... and one phone number at least is mandatory...
+        with emptied_fields(partner, "phone", "mobile"):
+            with self.assertRaises(ColissimoError) as err:
+                partner.colissimo_delivery_data()
+        self.assertEqual(
+            err.exception.args,
+            ("A phone number is required to generate a Colissimo label!",),
+        )
+
+        # ... unless asked to not raise
+        new_expected = expected.copy()
+        new_expected.update({"email": "", "mobileNumber": "", "phoneNumber": ""})
+        with emptied_fields(partner, "email", "phone", "mobile"):
+            self.assertEqual(
+                partner.colissimo_delivery_data(raise_on_error=False),
+                new_expected,
+            )


### PR DESCRIPTION
This is useless as these fields are mandatory in the self troubleshooting html page, so the user will add values.