### PR TITLE
Inverse priority between scrapped and no rental for too long test for fees concerned devices

### DIFF
--- a/rental_fees/models/rental_fees_computation.py
+++ b/rental_fees/models/rental_fees_computation.py
@@ -707,16 +707,7 @@ class RentalFeesComputation(models.Model):
                 period["fees"] = sum(amount for _ds, _de, amount in monthly_fees)
                 device_fees += period["fees"]
 
-            if no_rental_limit:
-                self._add_compensation(
-                    fees_def,
-                    "no_rental_compensation",
-                    device,
-                    delivery_date,
-                    device_fees,
-                    no_rental_limit,
-                )
-            elif device in scrapped_devices:
+            if device in scrapped_devices:
                 self._add_compensation(
                     fees_def,
                     "lost_device_compensation",
@@ -724,6 +715,15 @@ class RentalFeesComputation(models.Model):
                     delivery_date,
                     device_fees,
                     scrapped_devices[device]["date"],
+                )
+            elif no_rental_limit:
+                self._add_compensation(
+                    fees_def,
+                    "no_rental_compensation",
+                    device,
+                    delivery_date,
+                    device_fees,
+                    no_rental_limit,
                 )
             else:
                 self._add_fees_periods(device, periods)

--- a/rental_fees/tests/test_rental_fees_computation.py
+++ b/rental_fees/tests/test_rental_fees_computation.py
@@ -482,7 +482,7 @@ class RentalFeesComputationTC(RentalFeesTC):
         self.assertFalse(comp.rental_details().mapped("fees"))
 
     def test_compute_no_rental_compensation_non_zero_2(self):
-        "No rental conditions fulfilled: compensation occurs then no other compensation"
+        "No rental then lost lead to exactly one compensation"
 
         contract = self.env["contract.contract"].of_sale(self.so)[0]
         self.send_device("N/S 1", contract, "2021-02-01")
@@ -496,8 +496,7 @@ class RentalFeesComputationTC(RentalFeesTC):
         self.scrap_device(device, date(2021, 12, 1))  # after no rental limit!
 
         comp = self.compute("2022-04-01")
-        self.assertEqual(comp.details("no_rental_compensation").mapped("fees"), [300.0])
-        self.assertFalse(comp.details("lost_device_compensation").mapped("fees"))
+        self.assertEqual(comp.compensation_details().mapped("fees"), [300.0])
         self.assertFalse(comp.rental_details().mapped("fees"))
 
     def test_compute_excluded_device(self):


### PR DESCRIPTION
... otherwise all scrapped devices end-up as not rented for too long which is not accurate and looks bad for Commown as a supplier.