### PR TITLE
Fix domain as string crashes search in the rental fees def order_ids field

### DIFF
--- a/rental_fees/models/rental_fees_definition.py
+++ b/rental_fees/models/rental_fees_definition.py
@@ -103,12 +103,6 @@ class RentalFeesDefinition(models.Model):
     order_ids = fields.Many2many(
         comodel_name="purchase.order",
         string="Purchase orders",
-        domain=(
-            "["
-            " ('partner_id', '=', partner_id),"
-            " ('order_line.product_id.product_tmpl_id', '=', product_template_id)"
-            "]"
-        ),
     )
 
     line_ids = fields.One2many(

--- a/rental_fees/views/rental_fees_definition.xml
+++ b/rental_fees/views/rental_fees_definition.xml
@@ -73,7 +73,7 @@
             </field>
           </group>
           <group name="orders">
-            <field name="order_ids" widget="many2many" />
+            <field name="order_ids" widget="many2many" domain="[('partner_id', '=', partner_id), ('order_line.product_id.product_tmpl_id', '=', product_template_id)]"/>
           </group>
           <group name="lines">
             <field name="line_ids">


### PR DESCRIPTION
When searching in the order_ids field by string, the domain of the field is appended to the search. It crashes in the normalize_domain function, which expects a tuple or list domain, not a string.

We work around the problem by moving the domain into the view.