### PR TITLE
Fix wrong purchase price computation in rental fees

### DIFF
--- a/rental_fees/models/rental_fees_definition.py
+++ b/rental_fees/models/rental_fees_definition.py
@@ -199,9 +199,12 @@ class RentalFeesDefinition(models.Model):
                 ("move_ids.move_line_ids.lot_id", "=", device.id),
             ]
         )
-        # PO line price is indicative, use the invoice lines mean price
+        # PO line price is indicative, use the mean price of all invoice lines
+        # concerning this device's product
         inv_lines = po_line.invoice_lines.filtered(
-            lambda il: il.invoice_id.state != "cancel"
+            lambda il: (
+                il.invoice_id.state != "cancel" and il.product_id == device.product_id
+            )
         )
         if not inv_lines:
             msg = _(


### PR DESCRIPTION
When a compensation occurs for a given device, its purchase price (reduced as agreed in the contract) is computed using the invoices attached to the PO. Before the patch, all invoiced products were used to compute the price (as their mean price), which was wrong as different products may sometimes be bought and related to the initial PO line (which is bad but occurs when the user modifies the po-generated invoice line and changes the product). We now filter by product to avoid a wrong price computation for the device.