### PR TITLE
Fix contract_template_line_id domain in contract line edition view

### DIFF
--- a/contract_variable_discount/views/contract.xml
+++ b/contract_variable_discount/views/contract.xml
@@ -13,13 +13,14 @@
 
       <xpath expr="//field[@name='contract_line_ids']"
              position="attributes">
-        <attribute name="context">{"contract_id": active_id}</attribute>
+        <attribute name="context">{"default_contract_id": active_id, "default_contract_template_id": contract_template_id}</attribute>
       </xpath>
 
       <!-- Insert `variable_discount` before `discount` -->
       <xpath expr="//field[@name='contract_line_ids']/tree/field[@name='discount']"
              position="before">
         <field name="specific_discount_line_ids"/>
+        <field name="contract_template_id" invisible="1"/>
         <field name="contract_template_line_id"/>
         <field name="variable_discount"/>
       </xpath>
@@ -40,6 +41,7 @@
     <field name="arch" type="xml">
 
       <field name="discount" position="after">
+        <field name="contract_template_id" invisible="1"/>
         <field name="contract_template_line_id"/>
       </field>
 

--- a/product_rental/models/contract.py
+++ b/product_rental/models/contract.py
@@ -30,18 +30,17 @@ def _rental_products(contract_descr):
 class ContractLine(models.Model):
     _inherit = "contract.line"
 
+    contract_template_id = fields.Many2one(
+        string="Contract template",
+        related="contract_id.contract_template_id",
+    )
+
     contract_template_line_id = fields.Many2one(
         string="Contract template line",
         help="Contract template line which generated current contract line",
         comodel_name="contract.template.line",
-        domain=lambda self: self._domain_contract_template_line_id(),
+        domain='[("contract_id", "=", contract_template_id)]',
     )
-
-    def _domain_contract_template_line_id(self):
-        contract = self.contract_id
-        if not contract and "contract_id" in self.env.context:
-            contract = contract.browse(self.env.context["contract_id"])
-        return [("contract_id", "=", contract.contract_template_id.id)]
 
 
 class Contract(models.Model):


### PR DESCRIPTION
The proposed values were not taking the contract template of the contract into account, now they do.