### PR TITLE
Add ability to exclude devices from fees without a financial compensation

### DIFF
--- a/rental_fees/i18n/de.po
+++ b/rental_fees/i18n/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-04 09:46+0000\n"
+"POT-Creation-Date: 2024-06-05 14:37+0000\n"
 "PO-Revision-Date: 2024-02-14 08:53+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
@@ -346,7 +346,7 @@ msgstr ""
 
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition__excluded_devices
-msgid "Explicitely excluded devices (with compensation)"
+msgid "Explicitely excluded devices"
 msgstr ""
 
 #. module: rental_fees
@@ -495,6 +495,13 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,help:rental_fees.field_rental_fees_computation__message_has_error
 msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_rental_fees_excluded_device__with_compensation
+msgid ""
+"If inactive, the device will be completely absent of the fees computation, "
+"as if it was never bought"
 msgstr ""
 
 #. module: rental_fees
@@ -956,6 +963,11 @@ msgstr ""
 #. module: rental_fees
 #: selection:rental_fees.definition_line,duration_unit:0
 msgid "Weeks"
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_rental_fees_excluded_device__with_compensation
+msgid "With compensation"
 msgstr ""
 
 #. module: rental_fees

--- a/rental_fees/i18n/fr.po
+++ b/rental_fees/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-04 09:46+0000\n"
-"PO-Revision-Date: 2024-06-04 13:05+0200\n"
+"POT-Creation-Date: 2024-06-05 14:37+0000\n"
+"PO-Revision-Date: 2024-06-05 16:55+0200\n"
 "Last-Translator: <florent@commown.coop>\n"
 "Language-Team: Commown\n"
 "Language: French\n"
@@ -355,8 +355,8 @@ msgstr "Pénalité pour exclusion de l'appareil"
 
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition__excluded_devices
-msgid "Explicitely excluded devices (with compensation)"
-msgstr "Appareils exclus manuellement (avec pénalité)"
+msgid "Explicitely excluded devices"
+msgstr "Appareils exclus"
 
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_computation__fees
@@ -509,10 +509,19 @@ msgid "If checked, some messages have a delivery error."
 msgstr "Si actif, certains messages ont une erreur de livraison."
 
 #. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_rental_fees_excluded_device__with_compensation
+msgid ""
+"If inactive, the device will be completely absent of the fees computation, "
+"as if it was never bought"
+msgstr "Lorsque décoché, l'appareil sera complètement absent du calcul des commissions, comme s'il n'avait jamais été acheté"
+
+#. module: rental_fees
 #: code:addons/rental_fees/models/rental_fees_definition.py:266
 #, python-format
 msgid "Ignoring fees def '%s', superseded by a more recent one."
-msgstr "La définition de commissions '%s' a été ignorée car remplacée par une plus récente."
+msgstr ""
+"La définition de commissions '%s' a été ignorée car remplacée par une plus "
+"récente."
 
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition_line__sequence
@@ -718,13 +727,17 @@ msgstr "Partenaire"
 #: code:addons/rental_fees/models/rental_fees_computation.py:533
 #, python-format
 msgid "Please set the invoice model on all fees definitions."
-msgstr "Merci d'utiliser le même modèle de facture pour toutes les définitions de commissions."
+msgstr ""
+"Merci d'utiliser le même modèle de facture pour toutes les définitions de "
+"commissions."
 
 #. module: rental_fees
 #: code:addons/rental_fees/models/rental_fees_computation.py:544
 #, python-format
 msgid "Please use the same invoice model on all fees definition."
-msgstr "Merci d'utiliser le même modèle de facture pour toutes les définitions de commissions."
+msgstr ""
+"Merci d'utiliser le même modèle de facture pour toutes les définitions de "
+"commissions."
 
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_computation_detail__product_template_id
@@ -993,6 +1006,11 @@ msgid "Weeks"
 msgstr "Semaines"
 
 #. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_rental_fees_excluded_device__with_compensation
+msgid "With compensation"
+msgstr "Avec pénalité"
+
+#. module: rental_fees
 #: selection:rental_fees.definition_line,duration_unit:0
 msgid "Years"
 msgstr "Années"
@@ -1002,7 +1020,9 @@ msgstr "Années"
 msgid ""
 "[${object.company_id.name}] Fees to be invoices as of ${format_date(object."
 "fees_computation_id.until_date)}"
-msgstr "[${object.company_id.name}] Commissions à facturer au ${format_date(object.fees_computation_id.until_date)}"
+msgstr ""
+"[${object.company_id.name}] Commissions à facturer au ${format_date(object."
+"fees_computation_id.until_date)}"
 
 #. module: rental_fees
 #: model:ir.actions.act_window,name:rental_fees.action_compare_selected_computations
@@ -1024,7 +1044,12 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.actions.server,name:rental_fees.update_defs_with_new_pos
 msgid "[commown] Update fees definitions with the new POs"
-msgstr "[commown] Mettre à jour des définitions de commissions avec les nouveaux achats"
+msgstr ""
+"[commown] Mettre à jour des définitions de commissions avec les nouveaux "
+"achats"
+
+#~ msgid "Explicitely excluded devices (with compensation)"
+#~ msgstr "Appareils exclus manuellement (avec pénalité)"
 
 #~ msgid "Please set the invoice model on the fees definition."
 #~ msgstr ""

--- a/rental_fees/i18n/rental_fees.pot
+++ b/rental_fees/i18n/rental_fees.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-04 09:46+0000\n"
-"PO-Revision-Date: 2024-06-04 09:46+0000\n"
+"POT-Creation-Date: 2024-06-05 14:37+0000\n"
+"PO-Revision-Date: 2024-06-05 14:37+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -299,7 +299,7 @@ msgstr ""
 
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition__excluded_devices
-msgid "Explicitely excluded devices (with compensation)"
+msgid "Explicitely excluded devices"
 msgstr ""
 
 #. module: rental_fees
@@ -443,6 +443,11 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,help:rental_fees.field_rental_fees_computation__message_has_error
 msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_rental_fees_excluded_device__with_compensation
+msgid "If inactive, the device will be completely absent of the fees computation, as if it was never bought"
 msgstr ""
 
 #. module: rental_fees
@@ -889,6 +894,11 @@ msgstr ""
 #. module: rental_fees
 #: selection:rental_fees.definition_line,duration_unit:0
 msgid "Weeks"
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_rental_fees_excluded_device__with_compensation
+msgid "With compensation"
 msgstr ""
 
 #. module: rental_fees

--- a/rental_fees/models/rental_fees_computation.py
+++ b/rental_fees/models/rental_fees_computation.py
@@ -713,7 +713,7 @@ class RentalFeesComputation(models.Model):
     def _run_for_fees_def(self, fees_def):
 
         scrapped_devices = fees_def.scrapped_devices(self.until_date)
-        excluded_devices = {ed.device: ed.reason for ed in fees_def.excluded_devices}
+        excluded_devices = {ed.device: ed for ed in fees_def.excluded_devices}
 
         for device, delivery_data in fees_def.devices_delivery().items():
             try:
@@ -742,13 +742,15 @@ class RentalFeesComputation(models.Model):
         delivery_date = delivery_data["date"]
 
         if device in excluded_devices:
-            self._add_compensation(
-                fees_def,
-                "excluded_device_compensation",
-                device,
-                delivery_date,
-                reason=excluded_devices[device],
-            )
+            excluded_device = excluded_devices[device]
+            if excluded_device.with_compensation:
+                self._add_compensation(
+                    fees_def,
+                    "excluded_device_compensation",
+                    device,
+                    delivery_date,
+                    reason=excluded_device.reason,
+                )
             return
 
         periods = self.rental_periods(device)

--- a/rental_fees/models/rental_fees_definition.py
+++ b/rental_fees/models/rental_fees_definition.py
@@ -92,7 +92,7 @@ class RentalFeesDefinition(models.Model):
 
     excluded_devices = fields.One2many(
         comodel_name="rental_fees.excluded_device",
-        string="Explicitely excluded devices (with compensation)",
+        string="Explicitely excluded devices",
         inverse_name="fees_definition_id",
         copy=False,
     )
@@ -510,6 +510,15 @@ class RentalFeesExcludedDevice(models.Model):
     )
 
     reason = fields.Char()
+
+    with_compensation = fields.Boolean(
+        string="With compensation",
+        default=True,
+        help=(
+            "If inactive, the device will be completely absent"
+            " of the fees computation, as if it was never bought"
+        ),
+    )
 
     def _default_device_domain(self):
         key = "default_fees_definition_id"

--- a/rental_fees/views/rental_fees_definition.xml
+++ b/rental_fees/views/rental_fees_definition.xml
@@ -69,6 +69,7 @@
                 <field name="device_domain" invisible="1"/>
                 <field name="device" domain="device_domain"/>
                 <field name="reason"/>
+                <field name="with_compensation"/>
               </tree>
             </field>
           </group>


### PR DESCRIPTION
Use case: a computer was returned to the supplier, as if it was never bought.