### PR TITLE
Robustify the order ids update of the rental definitions

### DIFF
--- a/rental_fees/__manifest__.py
+++ b/rental_fees/__manifest__.py
@@ -23,6 +23,7 @@
         "security/ir.model.access.csv",
         "data/actions.xml",
         "data/mail_template.xml",
+        "views/purchase_order.xml",
         "views/rental_fees_computation.xml",
         "views/rental_fees_definition.xml",
         "views/rental_fees_report.xml",

--- a/rental_fees/i18n/de.po
+++ b/rental_fees/i18n/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-05 14:37+0000\n"
+"POT-Creation-Date: 2024-06-07 13:01+0000\n"
 "PO-Revision-Date: 2024-02-14 08:53+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:432
+#: code:addons/rental_fees/models/rental_fees_definition.py:458
 #, python-format
 msgid ""
 "\n"
@@ -79,19 +79,19 @@ msgstr ""
 "</div>\n"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:479
+#: code:addons/rental_fees/models/rental_fees_definition.py:505
 #, python-format
 msgid "%(fixed_amount)s %(currency)s (fixed)"
 msgstr "%(fixed_amount)s %(currency)s (fest)"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:295
+#: code:addons/rental_fees/models/rental_fees_definition.py:317
 #, python-format
 msgid "%s is not fully delivered."
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:284
+#: code:addons/rental_fees/models/rental_fees_definition.py:306
 #, python-format
 msgid "%s is still in an early state."
 msgstr ""
@@ -116,7 +116,7 @@ msgid "Actual"
 msgstr "Tatsächlich"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:299
+#: code:addons/rental_fees/models/rental_fees_definition.py:321
 #, python-format
 msgid "Adding new POs to fees def '%s': %s"
 msgstr ""
@@ -132,7 +132,7 @@ msgid "Amount"
 msgstr "Betrag"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:167
+#: code:addons/rental_fees/models/rental_fees_definition.py:186
 #, python-format
 msgid ""
 "At least one other fees def, %s (id %d), has the same partner, product & "
@@ -157,6 +157,12 @@ msgstr "B2B"
 #: selection:rental_fees.computation.detail,market:0
 msgid "B2C"
 msgstr "B2C"
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_definition.py:170
+#, python-format
+msgid "Cannot add an excluded-from-fees PO to a fees definition"
+msgstr ""
 
 #. module: rental_fees
 #: code:addons/rental_fees/models/rental_fees_computation.py:604
@@ -284,7 +290,7 @@ msgid "Device Domain"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:234
+#: code:addons/rental_fees/models/rental_fees_definition.py:259
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_definition_view_form
 #, python-format
 msgid "Devices"
@@ -340,6 +346,11 @@ msgid ""
 msgstr ""
 
 #. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_purchase_order__exclude_from_fees
+msgid "Exclude from fees"
+msgstr ""
+
+#. module: rental_fees
 #: selection:rental_fees.computation.detail,fees_type:0
 msgid "Excluded device compensation"
 msgstr ""
@@ -384,7 +395,7 @@ msgid "Fees definition lines"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:148
+#: code:addons/rental_fees/models/rental_fees_definition.py:160
 #, python-format
 msgid ""
 "Fees definition purchase orders partners must all be the same as the fees "
@@ -442,6 +453,11 @@ msgid "Followers (Partners)"
 msgstr ""
 
 #. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_purchase_order__exclude_from_fees
+msgid "Force exclusion from fees even if a matching fees definition exists"
+msgstr ""
+
+#. module: rental_fees
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_detail_view_search
 msgid "Forecast"
 msgstr ""
@@ -454,6 +470,14 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_computation_detail__from_date
 msgid "From date"
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_rental_fees_definition__valid_from
+msgid ""
+"From this date on and until a new fees definition with the same (partner, "
+"product) couple and with a more recent date arrives, all POs with an order "
+"date after this will be attributed to this fees definition."
 msgstr ""
 
 #. module: rental_fees
@@ -502,12 +526,6 @@ msgstr ""
 msgid ""
 "If inactive, the device will be completely absent of the fees computation, "
 "as if it was never bought"
-msgstr ""
-
-#. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:266
-#, python-format
-msgid "Ignoring fees def '%s', superseded by a more recent one."
 msgstr ""
 
 #. module: rental_fees
@@ -644,7 +662,13 @@ msgid "Name"
 msgstr "Name"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:217
+#: code:addons/rental_fees/models/rental_fees_definition.py:330
+#, python-format
+msgid "No fees definition needs updating."
+msgstr ""
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_definition.py:242
 #, python-format
 msgid "No price for device %(serial)s: its PO line has no invoice, see %(po)s"
 msgstr ""
@@ -733,7 +757,7 @@ msgid "Purchase Order"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/purchase_order.py:16
+#: code:addons/rental_fees/models/purchase_order.py:22
 #, python-format
 msgid ""
 "Purchase order's partner and its fees definition must have the same partner"
@@ -845,7 +869,7 @@ msgid "Send report for invoicing"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:134
+#: code:addons/rental_fees/models/rental_fees_definition.py:146
 #, python-format
 msgid ""
 "Some non-draft computations use this fees definition. Please remove or set "
@@ -941,6 +965,11 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,help:rental_fees.field_rental_fees_definition_line__sequence
 msgid "Useful to order the periods in the fees definition"
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition__valid_from
+msgid "Valid from"
 msgstr ""
 
 #. module: rental_fees

--- a/rental_fees/i18n/fr.po
+++ b/rental_fees/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-05 14:37+0000\n"
-"PO-Revision-Date: 2024-06-05 16:55+0200\n"
+"POT-Creation-Date: 2024-06-07 13:01+0000\n"
+"PO-Revision-Date: 2024-06-07 17:41+0200\n"
 "Last-Translator: <florent@commown.coop>\n"
 "Language-Team: Commown\n"
 "Language: French\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:432
+#: code:addons/rental_fees/models/rental_fees_definition.py:458
 #, python-format
 msgid ""
 "\n"
@@ -80,19 +80,19 @@ msgstr ""
 "</div>\n"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:479
+#: code:addons/rental_fees/models/rental_fees_definition.py:505
 #, python-format
 msgid "%(fixed_amount)s %(currency)s (fixed)"
 msgstr "%(fixed_amount)s %(currency)s (fixe)"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:295
+#: code:addons/rental_fees/models/rental_fees_definition.py:317
 #, python-format
 msgid "%s is not fully delivered."
 msgstr "%s est partiellement réceptionnée"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:284
+#: code:addons/rental_fees/models/rental_fees_definition.py:306
 #, python-format
 msgid "%s is still in an early state."
 msgstr "%s est encore dans un statut peu avancé"
@@ -117,7 +117,7 @@ msgid "Actual"
 msgstr "Effectif"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:299
+#: code:addons/rental_fees/models/rental_fees_definition.py:321
 #, python-format
 msgid "Adding new POs to fees def '%s': %s"
 msgstr "Ajoût de nouveaux achats à la définition de commissions '%s' : %s"
@@ -133,7 +133,7 @@ msgid "Amount"
 msgstr "Montant"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:167
+#: code:addons/rental_fees/models/rental_fees_definition.py:186
 #, python-format
 msgid ""
 "At least one other fees def, %s (id %d), has the same partner, product & "
@@ -158,6 +158,12 @@ msgstr "B2B"
 #: selection:rental_fees.computation.detail,market:0
 msgid "B2C"
 msgstr "B2C"
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_definition.py:170
+#, python-format
+msgid "Cannot add an excluded-from-fees PO to a fees definition"
+msgstr "Il n'est pas possible de rajouter un achat paramétré comme exclu du commissionnement"
 
 #. module: rental_fees
 #: code:addons/rental_fees/models/rental_fees_computation.py:604
@@ -288,7 +294,7 @@ msgid "Device Domain"
 msgstr "Domaine de sélection de l'appareil"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:234
+#: code:addons/rental_fees/models/rental_fees_definition.py:259
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_definition_view_form
 #, python-format
 msgid "Devices"
@@ -349,6 +355,11 @@ msgstr ""
 "de non-location d'un appareil ne seront plus dues."
 
 #. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_purchase_order__exclude_from_fees
+msgid "Exclude from fees"
+msgstr "Exclus du commissionnement"
+
+#. module: rental_fees
 #: selection:rental_fees.computation.detail,fees_type:0
 msgid "Excluded device compensation"
 msgstr "Pénalité pour exclusion de l'appareil"
@@ -393,7 +404,7 @@ msgid "Fees definition lines"
 msgstr "Lignes de définition des commissions"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:148
+#: code:addons/rental_fees/models/rental_fees_definition.py:160
 #, python-format
 msgid ""
 "Fees definition purchase orders partners must all be the same as the fees "
@@ -453,6 +464,11 @@ msgid "Followers (Partners)"
 msgstr "Abonnés (Partenaires)"
 
 #. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_purchase_order__exclude_from_fees
+msgid "Force exclusion from fees even if a matching fees definition exists"
+msgstr "Exclure de force du commissionnement même si une définition de commissions correspond"
+
+#. module: rental_fees
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_detail_view_search
 msgid "Forecast"
 msgstr "Prévisionnel"
@@ -466,6 +482,18 @@ msgstr "Prévisionnel"
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_computation_detail__from_date
 msgid "From date"
 msgstr "Date de début"
+
+#. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_rental_fees_definition__valid_from
+msgid ""
+"From this date on and until a new fees definition with the same (partner, "
+"product) couple and with a more recent date arrives, all POs with an order "
+"date after this will be attributed to this fees definition."
+msgstr ""
+"À partir de cette date et jusqu'à ce qu'une nouvelle définition de "
+"commissions avec le même couple (fournisseur, produit) et une date plus "
+"récente soit créée, tous les achats dont la date est postérieure seront "
+"attribués à cette définition de fees."
 
 #. module: rental_fees
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_view_form
@@ -513,15 +541,9 @@ msgstr "Si actif, certains messages ont une erreur de livraison."
 msgid ""
 "If inactive, the device will be completely absent of the fees computation, "
 "as if it was never bought"
-msgstr "Lorsque décoché, l'appareil sera complètement absent du calcul des commissions, comme s'il n'avait jamais été acheté"
-
-#. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:266
-#, python-format
-msgid "Ignoring fees def '%s', superseded by a more recent one."
 msgstr ""
-"La définition de commissions '%s' a été ignorée car remplacée par une plus "
-"récente."
+"Lorsque décoché, l'appareil sera complètement absent du calcul des "
+"commissions, comme s'il n'avait jamais été acheté"
 
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition_line__sequence
@@ -662,7 +684,13 @@ msgid "Name"
 msgstr "Nom"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:217
+#: code:addons/rental_fees/models/rental_fees_definition.py:330
+#, python-format
+msgid "No fees definition needs updating."
+msgstr "Aucune définition de commissions ne nécessite une mise à jour"
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_definition.py:242
 #, python-format
 msgid "No price for device %(serial)s: its PO line has no invoice, see %(po)s"
 msgstr ""
@@ -758,7 +786,7 @@ msgid "Purchase Order"
 msgstr "Commande fournisseur"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/purchase_order.py:16
+#: code:addons/rental_fees/models/purchase_order.py:22
 #, python-format
 msgid ""
 "Purchase order's partner and its fees definition must have the same partner"
@@ -876,7 +904,7 @@ msgid "Send report for invoicing"
 msgstr "Envoyer le rapport pour facturation"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:134
+#: code:addons/rental_fees/models/rental_fees_definition.py:146
 #, python-format
 msgid ""
 "Some non-draft computations use this fees definition. Please remove or set "
@@ -982,6 +1010,11 @@ msgid "Useful to order the periods in the fees definition"
 msgstr "Utile pour ordonner les périodes de définition des commissions"
 
 #. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition__valid_from
+msgid "Valid from"
+msgstr "Valide à partir de"
+
+#. module: rental_fees
 #: model:ir.model.fields,help:rental_fees.field_rental_fees_definition_line__duration_value
 msgid ""
 "Value of the duration of the period, in duration units. No duration_value "
@@ -1047,6 +1080,11 @@ msgid "[commown] Update fees definitions with the new POs"
 msgstr ""
 "[commown] Mettre à jour des définitions de commissions avec les nouveaux "
 "achats"
+
+#~ msgid "Ignoring fees def '%s', superseded by a more recent one."
+#~ msgstr ""
+#~ "La définition de commissions '%s' a été ignorée car remplacée par une "
+#~ "plus récente."
 
 #~ msgid "Explicitely excluded devices (with compensation)"
 #~ msgstr "Appareils exclus manuellement (avec pénalité)"

--- a/rental_fees/i18n/rental_fees.pot
+++ b/rental_fees/i18n/rental_fees.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-05 14:37+0000\n"
-"PO-Revision-Date: 2024-06-05 14:37+0000\n"
+"POT-Creation-Date: 2024-06-07 13:01+0000\n"
+"PO-Revision-Date: 2024-06-07 13:01+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:432
+#: code:addons/rental_fees/models/rental_fees_definition.py:458
 #, python-format
 msgid "\n"
 "%(err)s\n"
@@ -49,19 +49,19 @@ msgid "\n"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:479
+#: code:addons/rental_fees/models/rental_fees_definition.py:505
 #, python-format
 msgid "%(fixed_amount)s %(currency)s (fixed)"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:295
+#: code:addons/rental_fees/models/rental_fees_definition.py:317
 #, python-format
 msgid "%s is not fully delivered."
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:284
+#: code:addons/rental_fees/models/rental_fees_definition.py:306
 #, python-format
 msgid "%s is still in an early state."
 msgstr ""
@@ -82,7 +82,7 @@ msgid "Actual"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:299
+#: code:addons/rental_fees/models/rental_fees_definition.py:321
 #, python-format
 msgid "Adding new POs to fees def '%s': %s"
 msgstr ""
@@ -98,7 +98,7 @@ msgid "Amount"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:167
+#: code:addons/rental_fees/models/rental_fees_definition.py:186
 #, python-format
 msgid "At least one other fees def, %s (id %d), has the same partner, product & order"
 msgstr ""
@@ -118,6 +118,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_detail_view_search
 #: selection:rental_fees.computation.detail,market:0
 msgid "B2C"
+msgstr ""
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_definition.py:170
+#, python-format
+msgid "Cannot add an excluded-from-fees PO to a fees definition"
 msgstr ""
 
 #. module: rental_fees
@@ -242,7 +248,7 @@ msgid "Device Domain"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:234
+#: code:addons/rental_fees/models/rental_fees_definition.py:259
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_definition_view_form
 #, python-format
 msgid "Devices"
@@ -293,6 +299,11 @@ msgid "During this number of years after the device delivery, penalty fees will 
 msgstr ""
 
 #. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_purchase_order__exclude_from_fees
+msgid "Exclude from fees"
+msgstr ""
+
+#. module: rental_fees
 #: selection:rental_fees.computation.detail,fees_type:0
 msgid "Excluded device compensation"
 msgstr ""
@@ -337,7 +348,7 @@ msgid "Fees definition lines"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:148
+#: code:addons/rental_fees/models/rental_fees_definition.py:160
 #, python-format
 msgid "Fees definition purchase orders partners must all be the same as the fees definition's partner"
 msgstr ""
@@ -390,6 +401,11 @@ msgid "Followers (Partners)"
 msgstr ""
 
 #. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_purchase_order__exclude_from_fees
+msgid "Force exclusion from fees even if a matching fees definition exists"
+msgstr ""
+
+#. module: rental_fees
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_detail_view_search
 msgid "Forecast"
 msgstr ""
@@ -402,6 +418,11 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_computation_detail__from_date
 msgid "From date"
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model.fields,help:rental_fees.field_rental_fees_definition__valid_from
+msgid "From this date on and until a new fees definition with the same (partner, product) couple and with a more recent date arrives, all POs with an order date after this will be attributed to this fees definition."
 msgstr ""
 
 #. module: rental_fees
@@ -448,12 +469,6 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,help:rental_fees.field_rental_fees_excluded_device__with_compensation
 msgid "If inactive, the device will be completely absent of the fees computation, as if it was never bought"
-msgstr ""
-
-#. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:266
-#, python-format
-msgid "Ignoring fees def '%s', superseded by a more recent one."
 msgstr ""
 
 #. module: rental_fees
@@ -586,7 +601,13 @@ msgid "Name"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:217
+#: code:addons/rental_fees/models/rental_fees_definition.py:330
+#, python-format
+msgid "No fees definition needs updating."
+msgstr ""
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_definition.py:242
 #, python-format
 msgid "No price for device %(serial)s: its PO line has no invoice, see %(po)s"
 msgstr ""
@@ -673,7 +694,7 @@ msgid "Purchase Order"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/purchase_order.py:16
+#: code:addons/rental_fees/models/purchase_order.py:22
 #, python-format
 msgid "Purchase order's partner and its fees definition must have the same partner"
 msgstr ""
@@ -782,7 +803,7 @@ msgid "Send report for invoicing"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_definition.py:134
+#: code:addons/rental_fees/models/rental_fees_definition.py:146
 #, python-format
 msgid "Some non-draft computations use this fees definition. Please remove or set them draft to modify the definition."
 msgstr ""
@@ -874,6 +895,11 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,help:rental_fees.field_rental_fees_definition_line__sequence
 msgid "Useful to order the periods in the fees definition"
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition__valid_from
+msgid "Valid from"
 msgstr ""
 
 #. module: rental_fees

--- a/rental_fees/models/purchase_order.py
+++ b/rental_fees/models/purchase_order.py
@@ -1,8 +1,14 @@
-from odoo import _, api, models
+from odoo import _, api, fields, models
 
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
+
+    exclude_from_fees = fields.Boolean(
+        string="Exclude from fees",
+        help="Force exclusion from fees even if a matching fees definition exists",
+        default=False,
+    )
 
     @api.constrains("partner_id")
     def _check_partner_coherency(self):

--- a/rental_fees/models/rental_fees_definition.py
+++ b/rental_fees/models/rental_fees_definition.py
@@ -264,6 +264,8 @@ class RentalFeesDefinition(models.Model):
         Notify the user of added POs and when a PO is still draft or not fully received.
         """
 
+        update_done = False
+
         for fees_def in self:
 
             _pt = fees_def.product_template_id
@@ -313,8 +315,12 @@ class RentalFeesDefinition(models.Model):
                     msg % (fees_def.name, ", ".join(new_pos.mapped("name"))),
                     sticky=True,
                 )
-
                 fees_def.order_ids |= new_pos
+                update_done = True
+
+        if update_done is False:
+            msg = _("No fees definition needs updating.")
+            self.env.user.notify_warning(msg, sticky=True)
 
 
 class RentalFeesDefinitionLine(models.Model):

--- a/rental_fees/tests/common.py
+++ b/rental_fees/tests/common.py
@@ -26,6 +26,7 @@ class RentalFeesTC(DeviceAsAServiceTC):
             {
                 "name": "Test fees_def",
                 "partner_id": self.po.partner_id.id,
+                "valid_from": date(2000, 1, 1),
                 "product_template_id": self.storable_product.id,
                 "order_ids": [(6, 0, self.po.ids)],
                 "agreed_to_std_price_ratio": 0.4,

--- a/rental_fees/tests/test_rental_fees_definition.py
+++ b/rental_fees/tests/test_rental_fees_definition.py
@@ -176,3 +176,11 @@ class RentalFeesDefinitionTC(RentalFeesTC):
             ),
             "Adding new POs to fees def 'Old def': %s" % older_po.name,
         )
+
+        prev_warning = self.get_notifications("warning")
+        (old_fees_def | self.fees_def).action_update_with_new_pos()
+        self.assertNewNotifs(
+            "warning",
+            prev_warning,
+            "No fees definition needs updating.",
+        )

--- a/rental_fees/tests/test_rental_fees_definition.py
+++ b/rental_fees/tests/test_rental_fees_definition.py
@@ -38,6 +38,17 @@ class RentalFeesDefinitionTC(RentalFeesTC):
             ),
         )
 
+    def test_purchase_order_no_exclude_from_fees(self):
+        po2 = self.po.copy({"exclude_from_fees": True})
+
+        with self.assertRaises(ValidationError) as err:
+            self.fees_def.order_ids |= po2
+
+        self.assertEqual(
+            err.exception.name,
+            "Cannot add an excluded-from-fees PO to a fees definition",
+        )
+
     def test_purchase_order_no_override(self):
         "Check fees def cannot have partner & product & po in common"
         po2 = self.create_po_and_picking(

--- a/rental_fees/views/purchase_order.xml
+++ b/rental_fees/views/purchase_order.xml
@@ -1,0 +1,14 @@
+<odoo>
+
+  <record id="purchase_order_form" model="ir.ui.view">
+    <field name="name">purchase.order form</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.purchase_order_form"/>
+    <field name="arch" type="xml">
+        <field name="currency_id" position="after">
+          <field name="exclude_from_fees"/>
+        </field>
+    </field>
+  </record>
+
+</odoo>

--- a/rental_fees/views/rental_fees_definition.xml
+++ b/rental_fees/views/rental_fees_definition.xml
@@ -10,6 +10,7 @@
         <field name="name"/>
         <field name="partner_id"/>
         <field name="product_template_id"/>
+        <field name="valid_from"/>
         <field name="agreed_to_std_price_ratio" widget="percentage"/>
         <field name="order_ids" widget="many2many_tags" options="{'open': true}"/>
       </tree>
@@ -58,6 +59,7 @@
           <group name="main">
             <field name="partner_id"/>
             <field name="product_template_id"/>
+            <field name="valid_from"/>
             <field name="model_invoice_id"/>
             <field name="agreed_to_std_price_ratio" widget="percentage"/>
           </group>

--- a/rental_fees/views/rental_fees_definition.xml
+++ b/rental_fees/views/rental_fees_definition.xml
@@ -76,7 +76,7 @@
             </field>
           </group>
           <group name="orders">
-            <field name="order_ids" widget="many2many" domain="[('partner_id', '=', partner_id), ('order_line.product_id.product_tmpl_id', '=', product_template_id)]"/>
+            <field name="order_ids" widget="many2many" domain="[('partner_id', '=', partner_id), ('order_line.product_id.product_tmpl_id', '=', product_template_id), ('exclude_from_fees', '=', False)]"/>
           </group>
           <group name="lines">
             <field name="line_ids">


### PR DESCRIPTION
We now use a validation start date field in the fees definition that makes it more reliable to attribute a given PO to a fees definition according to its ordering by this valid_from field in the list of all fees definition with the same partner, product couple.