### PR TITLE
Fix the invoice merge preferences action on new token signature

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,8 @@
-requests-mock
+freezegun
 odfpy
 pyexcel-odsr
 pyexcel
+requests-mock
 
 # https://github.com/OCA/contract/pull/798 (12.0 port of contract_payment_auto)
 git+https://github.com/fcayre/contract@12.0-mig-contract_payment_auto-fix#subdirectory=setup/contract_payment_auto


### PR DESCRIPTION
The algorithm permitted invoice merge dates in the past. It was too complex too. Now we just use the more recently used preferences (= the one that generated the more recent invoice merge date) and increment the date according to the recurring parameters to make sure it is in the future.