### PR TITLE
Add a wizard to give a device to an employee

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Debian librairies
-        run: apt-get update -y && apt install pdftk texlive-extra-utils texlive-latex-recommended libreoffice libmagic1 librsvg2-bin -y
+        run: apt-get update -y && apt install poppler-utils texlive-extra-utils texlive-latex-recommended libreoffice libmagic1 librsvg2-bin -y
 
       - name: Install addons and dependencies
         run: oca_install_addons
@@ -46,6 +46,8 @@ jobs:
       #   run: manifestoo -d . check-licenses
       # - name: Check development status
       #   run: manifestoo -d . check-dev-status --default-dev-status=Beta
+      - name: Configure odoo
+        run: echo "limit_memory_hard = 5368709120" >> /etc/odoo.cfg && cat /etc/odoo.cfg
       - name: Initialize test db
         run: oca_init_test_database
       - name: Run tests

--- a/commown/models/contract.py
+++ b/commown/models/contract.py
@@ -40,11 +40,7 @@ class Contract(models.Model):
         for record in self:
             record.payment_issue_ids = (
                 self.env["project.task"]
-                .search(
-                    [
-                        ("invoice_id", "in", record._get_related_invoices().ids),
-                    ]
-                )
+                .search([("invoice_id", "in", record._get_related_invoices().ids)])
                 .ids
             )
 
@@ -59,11 +55,7 @@ class Contract(models.Model):
 
     def _format_transaction_label(self, invoice, last_date_invoiced):
         self.ensure_one()
-        lang = self.env["res.lang"].search(
-            [
-                ("code", "=", self.partner_id.lang),
-            ]
-        )
+        lang = self.env["res.lang"].search([("code", "=", self.partner_id.lang)])
         date_format = lang.date_format or "%m/%d/%Y"
         label = self.transaction_label
         label = label.replace("#START#", invoice.date_invoice.strftime(date_format))

--- a/commown_contractual_issue/views/project_task.xml
+++ b/commown_contractual_issue/views/project_task.xml
@@ -12,7 +12,7 @@
         <group name="partner_contract">
           <field name="partner_id"/>
           <field name="contract_id"
-                 attrs="{'required': [('require_contract', '=', True)], 'invisible': [('require_contract', '=', False)]}"
+                 attrs="{'required': [('require_contract', '=', True)], 'invisible': [('require_contract', '=', False), ('contract_id', '=', False)]}"
                  options="{'no_create': True}"/>
           <field name="commercial_partner_id" invisible="True"/>
           <field name="require_contract" invisible="True"/>

--- a/commown_devices/__manifest__.py
+++ b/commown_devices/__manifest__.py
@@ -28,6 +28,7 @@
         "data/action_project_task.xml",
         "data/action_purchase_order.xml",
         "data/action_stock_scrap.xml",
+        "data/contract_template.xml",
         "data/project_task.xml",
         "data/stock_location.xml",
         "security/ir.model.access.csv",
@@ -41,6 +42,7 @@
         "views/wizard_link_picking_po.xml",
         "views/wizard_link_po_invoice.xml",
         "views/wizard_project_task_picking.xml",
+        "views/wizard_project_task_to_employee.xml",
     ],
     "demo": [
         "demo/project_task.xml",

--- a/commown_devices/data/action_project_task.xml
+++ b/commown_devices/data/action_project_task.xml
@@ -1,5 +1,16 @@
 <odoo>
 
+  <record id="action_wizard_project_task_hand_over_to_employee" model="ir.actions.act_window">
+    <field name="name">[commown] Hand over a device to an employee</field>
+    <field name="src_model">project.task</field>
+    <field name="res_model">project.task.to.employee.wizard</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+    <field name="context">{'default_task_id': active_id}</field>
+    <field name="binding_model_id" ref="project.model_project_task" />
+  </record>
+
   <record id="action_wizard_project_task_involved_product_picking" model="ir.actions.server">
     <field name="name">[commown] REPAIR: Move involved product</field>
     <field name="model_id" ref="project.model_project_task"/>

--- a/commown_devices/data/contract_template.xml
+++ b/commown_devices/data/contract_template.xml
@@ -1,0 +1,11 @@
+<odoo>
+
+  <data noupdate="1">
+
+    <record id="contract_template_to_employee" model="contract.template">
+      <field name="name">Employee device</field>
+    </record>
+
+  </data>
+
+</odoo>

--- a/commown_devices/i18n/commown_devices.pot
+++ b/commown_devices/i18n/commown_devices.pot
@@ -1,15 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* commown_devices
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
-"PO-Revision-Date: 2024-09-11 10:33+0200\n"
-"Last-Translator: <florent@commown.coop>\n"
-"Language-Team: Commown\n"
-"Language: French\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-07 15:11+0000\n"
+"PO-Revision-Date: 2024-09-07 15:11+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -17,43 +17,35 @@ msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/wizard_project_task_to_employee.py:90
+#, python-format
 msgid "%(product)s for %(partner)s"
-msgstr "%(product)s pour %(partner)s"
+msgstr ""
 
 #. module: commown_devices
 #: model:mail.template,body_html:commown_devices.late_pickings_with_lots_mail
-msgid ""
-"<p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida "
-"Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Il y a ${object.env."
-"context.get('late_pickings')} transferts en retard.</p><p style=\"margin:0px "
-"0 1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, "
-"Verdana, Arial, sans-serif;\">Rendez vous sur&nbsp;<a href=\"https://shop."
-"commown.coop/web?debug#action=694&amp;active_id=5&amp;model=stock."
-"picking&amp;view_type=list&amp;menu_id=430\" target=\"_blank\" style=\"text-"
-"decoration:none;background-color:transparent;color:rgb(124, 123, 173);"
-"\">cette page</a> pour les traiter.<br></p>"
-msgstr "<p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Il y a ${object.env.context.get('late_pickings')} transferts en retard.</p><p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Rendez vous sur&nbsp;<a href=\"https://shop.commown.coop/web?debug#action=694&amp;active_id=5&amp;model=stock.picking&amp;view_type=list&amp;menu_id=430\" target=\"_blank\" style=\"text-decoration:none;background-color:transparent;color:rgb(124, 123, 173);\">cette page</a> pour les traiter.<br></p>"
+msgid "<p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Il y a ${object.env.context.get('late_pickings')} transferts en retard.</p><p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Rendez vous sur&nbsp;<a href=\"https://shop.commown.coop/web?debug#action=694&amp;active_id=5&amp;model=stock.picking&amp;view_type=list&amp;menu_id=430\" target=\"_blank\" style=\"text-decoration:none;background-color:transparent;color:rgb(124, 123, 173);\">cette page</a> pour les traiter.<br></p>"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_abstract_picking_wizard
 msgid "Abstract model to create a picking from a task"
-msgstr "Modèle abstrait pour la génération d'expéditions depuis une tâche"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__all_products
 msgid "All product to send"
-msgstr "Tout les produits à envoyer"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task__storable_product_id
 msgid "Article"
-msgstr "Article"
+msgstr ""
 
 #. module: commown_devices
 #: model:project.task.type,legend_blocked:commown_devices.diagnostic_stage
 #: model:project.task.type,legend_blocked:commown_devices.resiliated_stage
 msgid "Blocked"
-msgstr "Bloqué"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/wizard_project_task_picking.py:93
@@ -61,7 +53,6 @@ msgstr "Bloqué"
 #, python-format
 msgid "Can't move device: no device set on this task!"
 msgstr ""
-"Mouvement impossible : aucun appareil n'est paramétré sur cette tâche !"
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_crm_lead_picking_form
@@ -76,43 +67,39 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_to_employee
 msgid "Cancel"
-msgstr "Annuler"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__po_id_is_readonly
 msgid "Cannot change po if picking already has a linked po"
 msgstr ""
-"Impossible de changer l'ordre d'achat si le picking a déjàun ordre d'achat "
-"asocié"
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/wizard_project_task_to_employee.py:83
 #, python-format
 msgid "Cannot find given device. Is it really available?"
-msgstr "Impossible de trouver cet appareil. Est-il vraiment disponible ?"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_type__check_picking_assigned
 msgid "Check picking assigned when entering stage?"
-msgstr "Vérifier si un transfert est assigné à la tache?"
+msgstr ""
 
 #. module: commown_devices
 #: model:project.task.type,description:commown_devices.diagnostic_stage
-msgid ""
-"Check that there are no more open tickets - Support and/or Transfer and/or "
-"Breakage-Loss-Theft (as it doesn't make sense if the contract is terminated, "
-"or to help with end-of-contract billing if applicable ;)\n"
-msgstr "Check that there are no more open tickets - Support and/or Transfer and/or Breakage-Loss-Theft (as it doesn't make sense if the contract is terminated, or to help with end-of-contract billing if applicable ;)\n"
+msgid "Check that there are no more open tickets - Support and/or Transfer and/or Breakage-Loss-Theft (as it doesn't make sense if the contract is terminated, or to help with end-of-contract billing if applicable ;)\n"
+""
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__service_tmpl_id
 msgid "Configured product template"
-msgstr "Product template configuré"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_res_partner
 msgid "Contact"
-msgstr "Contact"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_contract_contract
@@ -121,27 +108,27 @@ msgstr "Contact"
 #: model:ir.model.fields,field_description:commown_devices.field_stock_production_lot__contract_id
 #: model:ir.model.fields,field_description:commown_devices.field_stock_scrap__contract_id
 msgid "Contract"
-msgstr "Contrat"
+msgstr ""
 
 #. module: commown_devices
 #: model:project.task.type,name:commown_devices.resiliated_stage
 msgid "Contract terminated, email sent"
-msgstr "Contrat résilié, mail envoyé"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_crm_lead_picking_wizard
 msgid "Create a picking from a lead"
-msgstr "Créer un transfert depuis une opportunité"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_involved_device_picking_wizard
 msgid "Create a picking of the device attached to a task"
-msgstr "Faire une expédition de l'appareil lié à une tâche"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_involved_nonserial_product_picking_wizard
 msgid "Create a picking of the nonserial product attached to a task"
-msgstr "Faire une expédition d'un module ou accéssoire lié à une tache"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__create_uid
@@ -159,7 +146,7 @@ msgstr "Faire une expédition d'un module ou accéssoire lié à une tache"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__create_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__create_uid
 msgid "Created by"
-msgstr "Créé par"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__create_date
@@ -177,7 +164,7 @@ msgstr "Créé par"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__create_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__create_date
 msgid "Created on"
-msgstr "Créé le"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__date
@@ -191,7 +178,7 @@ msgstr "Créé le"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__date
 msgid "Date"
-msgstr "Date"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,help:commown_devices.field_crm_lead_picking_wizard__date
@@ -205,49 +192,48 @@ msgstr "Date"
 #: model:ir.model.fields,help:commown_devices.field_project_task_outward_picking_wizard__date
 #: model:ir.model.fields,help:commown_devices.field_project_task_to_employee_wizard__date
 msgid "Defaults to now - To be set only to force a date"
-msgstr "Valeur par défaut : maintenant - À ne remplir que pour forcer une date"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__delivered_by_hand
 msgid "Delivered by hand?"
-msgstr "Remis en mains propres ?"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_picking_po_link_form
 msgid "Describe Picking Po Link"
-msgstr "Décrit un lien entre une expédition et un ordre d'achat"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_po_invoice_link_form
 msgid "Describe Po invoice Link"
-msgstr "Décrit un lien entre un ordre d'achat et une facture"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_po_invoice_link_line
 msgid "Describe a relation between a po_line and an invoice line"
 msgstr ""
-"Décrit une relation entre une ligne d'ordre d'achat et une ligne de facture"
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_move_po_link_line
 msgid "Describe a relation between a stock move and a purchase order line"
-msgstr "Décrit une relation entre un mouvement et une ligne d'ordre d'achat"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_product_service_storable_config
 msgid "Describe which storable products comes with a service"
-msgstr "Décrit quel produit stockable est associé à un service"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__location_dest_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__location_dest_id
 msgid "Destination"
-msgstr "Destination"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__contract_id
 msgid "Destination contract"
-msgstr "Contrat de destination"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task__lot_id
@@ -255,25 +241,25 @@ msgstr "Contrat de destination"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__lot_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__lot_id
 msgid "Device"
-msgstr "Appareil"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/project_task.py:212
 #, python-format
 msgid "Device field is not set"
-msgstr "Le chanp appareil n'est pas renseigné"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/project_task.py:220
 #, python-format
 msgid "Device is already in a scrap location"
-msgstr "L'appareil se trouve déja dans un emplacement de scrap"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.contract_contract_customer_form_view
 #: model_terms:ir.ui.view,arch_db:commown_devices.edit_project
 msgid "Devices"
-msgstr "Appareils"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__display_name
@@ -292,42 +278,33 @@ msgstr "Appareils"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__display_name
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__display_name
 msgid "Display Name"
-msgstr "Nom affiché"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,help:commown_devices.field_product_service_storable_config__storable_type
-msgid ""
-"Does current config concern the primary storable or the secondary storables "
-"of current product variants ?"
+msgid "Does current config concern the primary storable or the secondary storables of current product variants ?"
 msgstr ""
-"Est ce que la configuration concerne un produit stockable primaire ou un des "
-"produits stockable secondiare de la variante ?"
 
 #. module: commown_devices
 #: model:project.task.type,portal_displayed_name:commown_devices.diagnostic_stage
 msgid "Facturation et/ou Remboursement dépôt en cours"
-msgstr "Facturation et/ou Remboursement dépôt en cours"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/product.py:69
 #, python-format
-msgid ""
-"For product %s, two secondary variants derive from the same template, are "
-"you sure that there is no configuration mistake ?"
+msgid "For product %s, two secondary variants derive from the same template, are you sure that there is no configuration mistake ?"
 msgstr ""
-"Deux variantes présente dans les secondary_variant_ids du produit %s "
-"dérivent des mêmes templates. Êtes vous sur que il n'y a pas d'erreur de "
-"configuration ?"
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__parcel_type
 msgid "Generate a shipping label"
-msgstr "Générer une étiquette d'expédition"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_to_employee
 msgid "Give a device to an employee"
-msgstr "Confier l'appareil à un.e employé.e"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__id
@@ -346,54 +323,50 @@ msgstr "Confier l'appareil à un.e employé.e"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: commown_devices
 #: model:project.task.type,legend_normal:commown_devices.diagnostic_stage
 #: model:project.task.type,legend_normal:commown_devices.resiliated_stage
 msgid "In Progress"
-msgstr "En cours"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/stock_move.py:78
 #, python-format
-msgid ""
-"Inconsistent locations between move (id: %(move_id)s, picking id: "
-"%(picking_id)s) and contract (id: %(contract_id)s)"
-msgstr "Inconsistent locations between move (id: %(move_id)s, picking id: %(picking_id)s) and contract (id: %(contract_id)s)"
+msgid "Inconsistent locations between move (id: %(move_id)s, picking id: %(picking_id)s) and contract (id: %(contract_id)s)"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/stock_move.py:68
 #, python-format
-msgid ""
-"Inconsistent move (id: %(move_id)s, picking id: %(picking_id)s) contract "
-"(id: %(contract_id)s) and lot contract (id: %(lot_contract_id)s)"
-msgstr "Inconsistent move (id: %(move_id)s, picking id: %(picking_id)s) contract (id: %(contract_id)s) and lot contract (id: %(lot_contract_id)s)"
+msgid "Inconsistent move (id: %(move_id)s, picking id: %(picking_id)s) contract (id: %(contract_id)s) and lot contract (id: %(lot_contract_id)s)"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_location
 msgid "Inventory Locations"
-msgstr "Localisations d'inventaire"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__invoice_line_id_domain
 msgid "Invoice Line Id Domain"
-msgstr "Domaine des lignes de facturations"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__invoice_line_id
 msgid "Invoice lines"
-msgstr "Lignes de facturation"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_stock_move_line__is_contract_in
 msgid "Is Contract In"
-msgstr "Va vers le contrat"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__storable_type
 msgid "Is storable primary or secondary"
-msgstr "Le produit stockable est primaire ou secondaire"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard____last_update
@@ -412,7 +385,7 @@ msgstr "Le produit stockable est primaire ou secondaire"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard____last_update
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard____last_update
 msgid "Last Modified on"
-msgstr "Dernière Modification le"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__write_uid
@@ -430,7 +403,7 @@ msgstr "Dernière Modification le"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__write_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__write_uid
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__write_date
@@ -448,12 +421,12 @@ msgstr "Dernière mise à jour par"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__write_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__write_date
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr ""
 
 #. module: commown_devices
 #: model:mail.channel,name:commown_devices.late_pickings_with_lots_channel
 msgid "Late pickings channel"
-msgstr "Cannal éxpéditions en retard"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.server,name:commown_devices.late_pickings_with_lots_cron_ir_actions_server
@@ -461,112 +434,105 @@ msgstr "Cannal éxpéditions en retard"
 #: model:ir.cron,name:commown_devices.late_pickings_with_lots_cron
 #: model:mail.template,subject:commown_devices.late_pickings_with_lots_mail
 msgid "Late pickings with lots"
-msgstr "Expitition de lots en retard"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__lead_id
 msgid "Lead"
-msgstr "Piste"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/crm_lead.py:44
 #, python-format
 msgid "Lead has no assigned picking."
-msgstr "Aucun appareil expédié !"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_crm_lead
 msgid "Lead/Opportunity"
-msgstr "Piste/opportunité"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/stock_production_lot.py:35
 #, python-format
 msgid "Lot %s is already reserved"
-msgstr "Le lot %s est déjà reservé"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/stock_production_lot.py:33
 #, python-format
 msgid "Lot %s not found in available stock"
-msgstr "Le lot %s n'est pas trouvé dans le stock disponible"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task__lot_id_domain
 msgid "Lot Id Domain"
-msgstr "Domaine appareils suivits"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_production_lot
 msgid "Lot/Serial"
-msgstr "Lot/N° série"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_contract_contract__lot_ids
 msgid "Lots"
-msgstr "Appareils suivis"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_base_partner_merge_automatic_wizard
 msgid "Merge Partner Wizard"
-msgstr "Utilitaire de fusion de partenaires"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/stock_move.py:53
 #, python-format
 msgid "More than one contract on move %s lots"
-msgstr "Plus d'un contrat sur les appareils du mouvement %s"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/product.py:59
 #, python-format
 msgid "More than one primary variant configured for %s with attributes %s"
 msgstr ""
-"Il y a plus d'une variante primaire configurée pour le produit %s (avec les "
-"attributs %s)"
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_contract_contract__move_line_ids
 #: model:ir.model.fields,field_description:commown_devices.field_contract_contract__move_line_view_ids
 msgid "Move Lines"
-msgstr "Lignes de mouvements"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_device_picking_form
 msgid "Move involved device"
-msgstr "Déplacer l'appareil concerné"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_involved_nonserial_picking_form
 msgid "Move involved nonserial product"
-msgstr "Déplacer le module/accessoire"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/project_task.py:256
 #, python-format
 msgid "Move involved product"
-msgstr "Transférer les produits concernés"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__move_product_name
 msgid "Move product's name"
-msgstr "Produit"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__link_line_ids
 msgid "Move to purchase_line link"
-msgstr "Lien mouvement/Ligne d'ordre d'achat"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/common.py:65
 #, python-format
 msgid "Not enough %s under location(s) %s"
-msgstr "Pas assez de %s dans %s"
-
-#. module: commown_devices
-#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__lot_nb
-msgid "Number of lots"
-msgstr "Nombre d'appareils"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_crm_lead_picking_form
@@ -581,55 +547,55 @@ msgstr "Nombre d'appareils"
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_to_employee
 msgid "OK"
-msgstr "OK"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__picking_id
 msgid "Picking"
-msgstr "Expédition"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__wizard_id
 msgid "Picking Po wizard"
-msgstr "Wizard Expédition/Ordre d'achat"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/wizard_project_task_to_employee.py:66
 #, python-format
 msgid "Please set the task's partner before using this wizard"
-msgstr "Merci de paramétrer un partenaire avant de lancer cet utilitaire"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/wizard_project_task_to_employee.py:69
 #, python-format
 msgid "Please use an employee as a partner"
-msgstr "Merci d'utiliser un.e partenaire-employé.e"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__wizard_id
 msgid "Po invoice wizard"
-msgstr "Wizard Ordre d'achat/Facture"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__link_line_ids
 msgid "Po_line to invoice_line link"
-msgstr "Lien ligne d'achat/ligne de facturation"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__present_location_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__present_location_id
 msgid "Present location of the product"
-msgstr "Localisation actuelle"
+msgstr ""
 
 #. module: commown_devices
 #: selection:product.service_storable_config,storable_type:0
 msgid "Primary product"
-msgstr "Produit stockable primaire"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_product_product__primary_storable_variant_id
 msgid "Primary storable variant"
-msgstr "Produit stockable primaire"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_product_product
@@ -637,116 +603,116 @@ msgstr "Produit stockable primaire"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__variant_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__product_tmpl_id
 msgid "Product"
-msgstr "Article"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_move_line
 msgid "Product Moves (Stock Move Line)"
-msgstr "Mouvements de produit (lignes de mouvements)"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_product_template
 msgid "Product Template"
-msgstr "Modèle d'article"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__product_location
 msgid "Product will be sent from"
-msgstr "Le produit sera expédiés depuis"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__products_locations
 msgid "Products will be sent from"
-msgstr "Les produits seront expédiés depuis"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_project
 msgid "Project"
-msgstr "Projet"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__purchase_line_id_domain
 msgid "Purchase Line Id Domain"
-msgstr "Domaine des lignes d'achat"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__po_id
 msgid "Purchase order"
-msgstr "Ordre d'achat"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__purchase_line_id
 #: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__po_line_id
 msgid "Purchase order line"
-msgstr "Ligne d'ordre d'achat"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_quant
 msgid "Quants"
-msgstr "Quants"
+msgstr ""
 
 #. module: commown_devices
 #: model:project.task.type,legend_done:commown_devices.diagnostic_stage
 #: model:project.task.type,legend_done:commown_devices.resiliated_stage
 msgid "Ready for Next Stage"
-msgstr "Prêt pour la prochaine étape"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_inward_picking_form
 msgid "Receive a device"
-msgstr "Rapatrier un appareil"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_inward_picking_form
 msgid "Receive a not tracked product"
-msgstr "Rapatrier un produit non suivi"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__attribute_value_ids
 msgid "Restrict to variants with following attribute values"
-msgstr "S'applique aux variantes ayant ces valeurs d'attribut"
+msgstr ""
 
 #. module: commown_devices
 #: model:project.task.type,portal_displayed_name:commown_devices.resiliated_stage
 msgid "Résiliation traitée"
-msgstr "Résiliation traitée"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_scrap
 msgid "Scrap"
-msgstr "Scrap"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/project_task.py:238
 #, python-format
 msgid "Scrap device"
-msgstr "Mise au rebut"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/stock_scrap.py:16
 #, python-format
 msgid "Scrap must be done to use this action"
-msgstr "Le scrap doit être validé pour utiliser cette action"
+msgstr ""
 
 #. module: commown_devices
 #: selection:product.service_storable_config,storable_type:0
 msgid "Secondary product"
-msgstr "Produit stockable secondaire"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_product_product__secondary_storable_variant_ids
 msgid "Secondary storable variants"
-msgstr "Produits stockables secondaires"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__invoice_id
 msgid "Select invoice line from this invoice"
-msgstr "Séléctionner les lignes de factures depuis cette facture"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__po_id
 msgid "Select purchase order line from this purchase order"
-msgstr "Séléctionner les lignes d'achat depuis cet achat"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/crm_lead.py:29
@@ -754,75 +720,75 @@ msgstr "Séléctionner les lignes d'achat depuis cet achat"
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
 #, python-format
 msgid "Send a device"
-msgstr "Envoyer un appareil"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_outward_picking_form
 msgid "Send a not tracked product"
-msgstr "Envoyer un produit non suivi"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__prioritize_repackaged
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__prioritize_repackaged
 msgid "Send from repackaged devices if possible"
-msgstr "Envoyer depuis le stock reconditionné si quand c'est possible"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,help:commown_devices.field_project_task_to_employee_wizard__parcel_type
 msgid "Set this if you want to generate a shipping label at the same time"
-msgstr "Cocher cette case pour générer aussi une étiquette d'expédition"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__shipping_account_id
 msgid "Shipping account"
-msgstr "Compte d'expédition"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_stock_move_line__show_validate_picking
 msgid "Show Validate Picking"
-msgstr "Cacher/montrer les transferts non validés"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_contract_contract__show_all_view_move_lines
 msgid "Show all move lines"
-msgstr "Voir toutes les move line"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_move
 #: model:ir.model.fields,field_description:commown_devices.field_contract_contract__move_ids
 msgid "Stock Move"
-msgstr "Mouvement"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__move_id
 msgid "Stock move"
-msgstr "Mouvement"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.view_template_property_form
 msgid "Storable Configurations"
-msgstr "Configurations de produits stockable"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task__storable_product_id_domain
 msgid "Storable Product Id Domain"
-msgstr "Domaine du produit stockable"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__storable_tmpl_id
 msgid "Storable Tmpl"
-msgstr "Template du produit stockable"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__storable_variant_id
 msgid "Storable Variant"
-msgstr "Variante de produit stockable"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_product_product__storable_config_ids
 #: model:ir.model.fields,field_description:commown_devices.field_product_template__storable_config_ids
 msgid "Storable configurations"
-msgstr "Configurations de produits stockable"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task
@@ -836,42 +802,31 @@ msgstr "Configurations de produits stockable"
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__task_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__task_id
 msgid "Task"
-msgstr "Tâche"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_type
 msgid "Task Stage"
-msgstr "Étape de tâche"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/crm_lead.py:18
 #, python-format
-msgid ""
-"The contract has already assigned picking(s)!\n"
+msgid "The contract has already assigned picking(s)!\n"
 "Either cancel, scrap or validate it."
 msgstr ""
-"Le contrat est déjà associé à une expédition au moins !\n"
-"Il faut d'abord l'annuler, la valider ou mettre l'appareil au rebut."
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/project_task.py:203
 #, python-format
-msgid ""
-"These tasks can not be moved forward. There are no picking linked to those "
-"tasks: %s"
+msgid "These tasks can not be moved forward. There are no picking linked to those tasks: %s"
 msgstr ""
-"Ces taches ne peuvent pas être avancée(s) à cette étape car il n'y a pas de "
-"transfert associés aux taches suivantes: %s"
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/project_task.py:175
 #, python-format
-msgid ""
-"These tasks can not be moved forward. There are still device(s) associated "
-"with their contract: %s"
+msgid "These tasks can not be moved forward. There are still device(s) associated with their contract: %s"
 msgstr ""
-"Ces tâches ne peuvent pas être avancées à cette étape. Il y a encore un ou "
-"plusieurs appareils associé au(x) contrat(s) : %s"
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/wizard_project_task_picking.py:88
@@ -879,153 +834,149 @@ msgstr ""
 #, python-format
 msgid "This action should not be used in resiliation project"
 msgstr ""
-"Cette action ne doit pas être utilisée dans le projet résiliation.\n"
-"Utilisez plutôt l'action 'Rapatrier un appareil'"
 
 #. module: commown_devices
 #: model:project.task.type,name:commown_devices.diagnostic_stage
 msgid "To be invoiced"
-msgstr "À facturer"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__lot_ids
 msgid "Tracked Devices"
-msgstr "Appareils suivis"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_picking
 msgid "Transfer"
-msgstr "Transfert"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_contract_transfer_form
 msgid "Transfer device to new contract"
-msgstr "Transférer un appareil vers un autre contrat"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/stock_picking.py:35
 #, python-format
 msgid "Transfer must be done to use this action"
 msgstr ""
-"Le transfert doit être dans l'état \"fait\" avant d'utiliser cette action"
 
 #. module: commown_devices
 #: model:ir.model.fields,help:commown_devices.field_project_task_to_employee_wizard__delivered_by_hand
 msgid "Unset if the device must be sent by post"
-msgstr "Décocher si l'appareil doit être expédié"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_project__device_tracking
 #: model:ir.model.fields,field_description:commown_devices.field_project_task__device_tracking
 msgid "Use for device tracking?"
-msgstr "Suivi des appareils ?"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.contract_contract_customer_form_view
 msgid "Validate"
-msgstr "Valider"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__variant_id
 msgid "Variant"
-msgstr "Variante"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_to_employee_wizard
 msgid "Wizard to give a device to an employee"
-msgstr "Utilitaire pour confier un appareil à un.e employé.e"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_picking_po_link_wizard
 msgid "Wizard to link picking to purchase order"
-msgstr "Utilitaire pour lier expédition et achat"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_po_invoice_link_wizard
 msgid "Wizard to link purchase order line to invoices lines"
-msgstr "Utilitaire pour lier lignes d'achat et de facture"
+msgstr ""
 
 #. module: commown_devices
 #: code:addons/commown_devices/models/wizard_crm_lead_picking.py:113
 #, python-format
 msgid "You have to select a lot for each tracked product"
-msgstr "Vous devez séléctionner un lot par produit traqué"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.filters,name:commown_devices.late_pickings_with_lots_filter
 msgid "[Commown] Late transfer with lots"
-msgstr "[Commown] Expédition d'appareils en retard"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.server,name:commown_devices.action_set_picking_date_done_to_scheduled
 msgid "[LOG] Force picking and move dates to picking scheduled date"
 msgstr ""
-"[LOG] Forcer la date du transfert et mouvements associés à la date prévue"
 
 #. module: commown_devices
 #: model:ir.actions.server,name:commown_devices.action_set_scrap_date_done_to_scheduled
 msgid "[LOG] Force scrap and move date to scrap scheduled date"
-msgstr "[LOG] Forcer la date du scrap et mouvements associés à la date prévue"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_contract_transfer
 msgid "[commown] CONTRACT: Transfer involved device to another contract"
-msgstr "[commown] CONTRACT : Transférer l'appareil vers un autre contrat"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.server,name:commown_devices.action_generate_picking
 msgid "[commown] Generate picking"
-msgstr "[commown] Générer le mouvement d'appareils"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_hand_over_to_employee
 msgid "[commown] Hand over a device to an employee"
-msgstr "[Commown] Confier un appareil à un.e employé.e"
+msgstr ""
 
 #. module: commown_devices
 #: model:mail.template,name:commown_devices.late_pickings_with_lots_mail
 msgid "[commown] Late pickings with lots"
-msgstr "[Commown] Expédition d'appareils en retard"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_link_po_to_invoices
 msgid "[commown] Link PO lines to invoices lines"
-msgstr "[commown] Lier les lignes d'achat aux lignes de factures"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_link_picking_to_po
 msgid "[commown] Link Picking to Po"
-msgstr "[commown] Lier l'expédition à un achat"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.server,name:commown_devices.action_wizard_project_task_involved_product_picking
 msgid "[commown] REPAIR: Move involved product"
-msgstr "[Commown] RÉPARATION : transférer l'appareil concerné"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_inward_picking
 msgid "[commown] SUPPORT: Receive a device"
-msgstr "[commown] SUPPORT : Réceptionner un appareil"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_notracking_inward_picking
 msgid "[commown] SUPPORT: Receive a not tracked product"
-msgstr "[commown] SUPPORT : Rapatrier un appareil non suivi"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_outward_picking
 msgid "[commown] SUPPORT: Send a device"
-msgstr "[commown] SUPPORT : Envoyer un appareil"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_notracking_outward_picking
 msgid "[commown] SUPPORT: Send a not tracked product"
-msgstr "[commown] SUPPORT : Envoyer un appareil non suivi"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.actions.server,name:commown_devices.action_scrap_task_device
 msgid "[commown] Scrap involved device"
-msgstr "[commown] Mettre l'appareil concerné au rebut"
+msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_crm_lead_picking_form
@@ -1040,29 +991,30 @@ msgstr "[commown] Mettre l'appareil concerné au rebut"
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_to_employee
 msgid "or"
-msgstr "ou"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_contract_transfer_wizard
 msgid "project.task.contract_transfer.wizard"
-msgstr "project.task.contract_transfer.wizard"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_inward_picking_wizard
 msgid "project.task.inward.picking.wizard"
-msgstr "project.task.inward.picking.wizard"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_notracking_inward_picking_wizard
 msgid "project.task.notracking.inward.picking.wizard"
-msgstr "project.task.notracking.inward.picking.wizard"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_notracking_outward_picking_wizard
 msgid "project.task.notracking.outward.picking.wizard"
-msgstr "project.task.notracking.outward.picking.wizard"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_outward_picking_wizard
 msgid "project.task.outward.picking.wizard"
-msgstr "project.task.outward.picking.wizard"
+msgstr ""
+

--- a/commown_devices/i18n/de.po
+++ b/commown_devices/i18n/de.po
@@ -1,29 +1,49 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* commown_devices
+# 	* product_rental
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 12:40+0000\n"
-"PO-Revision-Date: 2023-04-05 12:40+0000\n"
-"Last-Translator: <>\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2024-09-07 15:11+0000\n"
+"PO-Revision-Date: 2024-05-14 19:27+0200\n"
+"Last-Translator: <florent@commown.coop>\n"
+"Language-Team: Commown\n"
+"Language: German\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/contract.py:127
+#: code:addons/commown_devices/models/wizard_project_task_to_employee.py:90
 #, python-format
-msgid "%(product)s n°%(serial)s"
-msgstr "%(product)s Nr. %(serial)s"
+msgid "%(product)s for %(partner)s"
+msgstr ""
+
+#. module: commown_devices
+#: model:mail.template,body_html:commown_devices.late_pickings_with_lots_mail
+msgid ""
+"<p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida "
+"Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Il y a ${object.env."
+"context.get('late_pickings')} transferts en retard.</p><p style=\"margin:0px "
+"0 1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, "
+"Verdana, Arial, sans-serif;\">Rendez vous sur&nbsp;<a href=\"https://shop."
+"commown.coop/web?debug#action=694&amp;active_id=5&amp;model=stock."
+"picking&amp;view_type=list&amp;menu_id=430\" target=\"_blank\" style=\"text-"
+"decoration:none;background-color:transparent;color:rgb(124, 123, 173);"
+"\">cette page</a> pour les traiter.<br></p>"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_abstract_picking_wizard
 msgid "Abstract model to create a picking from a task"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__all_products
+msgid "All product to send"
 msgstr ""
 
 #. module: commown_devices
@@ -35,23 +55,58 @@ msgstr ""
 #: model:project.task.type,legend_blocked:commown_devices.diagnostic_stage
 #: model:project.task.type,legend_blocked:commown_devices.resiliated_stage
 msgid "Blocked"
-msgstr ""
+msgstr "Blockiert"
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/wizard_project_task_picking.py:91
-#: code:addons/commown_devices/models/wizard_project_task_picking.py:239
+#: code:addons/commown_devices/models/wizard_project_task_picking.py:93
+#: code:addons/commown_devices/models/wizard_project_task_picking.py:300
 #, python-format
 msgid "Can't move device: no device set on this task!"
 msgstr ""
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_crm_lead_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_picking_po_link_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_po_invoice_link_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_contract_transfer_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_device_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_involved_nonserial_picking_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_inward_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_inward_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_outward_picking_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
-#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_to_employee
 msgid "Cancel"
 msgstr "Abbrechen"
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__po_id_is_readonly
+msgid "Cannot change po if picking already has a linked po"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/wizard_project_task_to_employee.py:83
+#, python-format
+msgid "Cannot find given device. Is it really available?"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_type__check_picking_assigned
+msgid "Check picking assigned when entering stage?"
+msgstr ""
+
+#. module: commown_devices
+#: model:project.task.type,description:commown_devices.diagnostic_stage
+msgid ""
+"Check that there are no more open tickets - Support and/or Transfer and/or "
+"Breakage-Loss-Theft (as it doesn't make sense if the contract is terminated, "
+"or to help with end-of-contract billing if applicable ;)\n"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__service_tmpl_id
+msgid "Configured product template"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_res_partner
@@ -60,14 +115,16 @@ msgstr "Kontakt"
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_contract_contract
-#: model:ir.model.fields,field_description:commown_devices.field_stock_picking__contract_id
-#: model:ir.model.fields,field_description:commown_devices.field_stock_quant__contract_id
+#: model:ir.model.fields,field_description:commown_devices.field_stock_move__contract_id
+#: model:ir.model.fields,field_description:commown_devices.field_stock_picking__contract_ids
+#: model:ir.model.fields,field_description:commown_devices.field_stock_production_lot__contract_id
+#: model:ir.model.fields,field_description:commown_devices.field_stock_scrap__contract_id
 msgid "Contract"
 msgstr "Vertrag"
 
 #. module: commown_devices
-#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__quant_ids
-msgid "Contract-related stock"
+#: model:project.task.type,name:commown_devices.resiliated_stage
+msgid "Contract terminated, email sent"
 msgstr ""
 
 #. module: commown_devices
@@ -81,25 +138,57 @@ msgid "Create a picking of the device attached to a task"
 msgstr ""
 
 #. module: commown_devices
+#: model:ir.model,name:commown_devices.model_project_task_involved_nonserial_product_picking_wizard
+msgid "Create a picking of the nonserial product attached to a task"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__create_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__create_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__create_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__create_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__create_uid
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__create_uid
 msgid "Created by"
 msgstr "Erstellt von"
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__create_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__create_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__create_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__create_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__create_date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__create_date
 msgid "Created on"
 msgstr "Erstellt am:"
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_abstract_picking_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__date
 msgid "Date"
 msgstr "Datum"
 
@@ -108,13 +197,48 @@ msgstr "Datum"
 #: model:ir.model.fields,help:commown_devices.field_project_task_abstract_picking_wizard__date
 #: model:ir.model.fields,help:commown_devices.field_project_task_contract_transfer_wizard__date
 #: model:ir.model.fields,help:commown_devices.field_project_task_involved_device_picking_wizard__date
+#: model:ir.model.fields,help:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__date
 #: model:ir.model.fields,help:commown_devices.field_project_task_inward_picking_wizard__date
+#: model:ir.model.fields,help:commown_devices.field_project_task_notracking_inward_picking_wizard__date
+#: model:ir.model.fields,help:commown_devices.field_project_task_notracking_outward_picking_wizard__date
 #: model:ir.model.fields,help:commown_devices.field_project_task_outward_picking_wizard__date
+#: model:ir.model.fields,help:commown_devices.field_project_task_to_employee_wizard__date
 msgid "Defaults to now - To be set only to force a date"
 msgstr ""
 
 #. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__delivered_by_hand
+msgid "Delivered by hand?"
+msgstr ""
+
+#. module: commown_devices
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_picking_po_link_form
+msgid "Describe Picking Po Link"
+msgstr ""
+
+#. module: commown_devices
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_po_invoice_link_form
+msgid "Describe Po invoice Link"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_po_invoice_link_line
+msgid "Describe a relation between a po_line and an invoice line"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_move_po_link_line
+msgid "Describe a relation between a stock move and a purchase order line"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_product_service_storable_config
+msgid "Describe which storable products comes with a service"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__location_dest_id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__location_dest_id
 msgid "Destination"
 msgstr ""
 
@@ -124,86 +248,213 @@ msgid "Destination contract"
 msgstr ""
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/contract.py:134
-#: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__lot_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task__lot_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__lot_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__lot_id
-#, python-format
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__lot_id
 msgid "Device"
 msgstr "Gerät"
 
 #. module: commown_devices
-#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__quant_nb
-msgid "Device number"
+#: code:addons/commown_devices/models/project_task.py:212
+#, python-format
+msgid "Device field is not set"
 msgstr ""
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/contract.py:132
+#: code:addons/commown_devices/models/project_task.py:220
+#, python-format
+msgid "Device is already in a scrap location"
+msgstr ""
+
+#. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.contract_contract_customer_form_view
 #: model_terms:ir.ui.view,arch_db:commown_devices.edit_project
-#, python-format
 msgid "Devices"
 msgstr "Geräte"
 
 #. module: commown_devices
-#: model:project.task.type,name:commown_devices.diagnostic_stage
-msgid "Diagnostic stage"
-msgstr ""
-
-#. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__display_name
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_abstract_picking_wizard__display_name
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__display_name
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__display_name
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__display_name
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__display_name
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__display_name
 msgid "Display Name"
 msgstr "Anzeigename"
 
 #. module: commown_devices
+#: model:ir.model.fields,help:commown_devices.field_product_service_storable_config__storable_type
+msgid ""
+"Does current config concern the primary storable or the secondary storables "
+"of current product variants ?"
+msgstr ""
+
+#. module: commown_devices
+#: model:project.task.type,portal_displayed_name:commown_devices.diagnostic_stage
+msgid "Facturation et/ou Remboursement dépôt en cours"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/product.py:69
+#, python-format
+msgid ""
+"For product %s, two secondary variants derive from the same template, are "
+"you sure that there is no configuration mistake ?"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__parcel_type
+msgid "Generate a shipping label"
+msgstr ""
+
+#. module: commown_devices
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_to_employee
+msgid "Give a device to an employee"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__id
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__id
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__id
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__id
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__id
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_abstract_picking_wizard__id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: commown_devices
 #: model:project.task.type,legend_normal:commown_devices.diagnostic_stage
 #: model:project.task.type,legend_normal:commown_devices.resiliated_stage
 msgid "In Progress"
+msgstr "In Arbeit"
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/stock_move.py:78
+#, python-format
+msgid ""
+"Inconsistent locations between move (id: %(move_id)s, picking id: "
+"%(picking_id)s) and contract (id: %(contract_id)s)"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/stock_move.py:68
+#, python-format
+msgid ""
+"Inconsistent move (id: %(move_id)s, picking id: %(picking_id)s) contract "
+"(id: %(contract_id)s) and lot contract (id: %(lot_contract_id)s)"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_stock_location
+msgid "Inventory Locations"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__invoice_line_id_domain
+msgid "Invoice Line Id Domain"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__invoice_line_id
+msgid "Invoice lines"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_stock_move_line__is_contract_in
+msgid "Is Contract In"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__storable_type
+msgid "Is storable primary or secondary"
 msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config____last_update
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_abstract_picking_wizard____last_update
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard____last_update
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard____last_update
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard____last_update
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard____last_update
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard____last_update
 msgid "Last Modified on"
 msgstr "Zuletzt geändert am"
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__write_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__write_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__write_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__write_uid
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__write_uid
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__write_uid
 msgid "Last Updated by"
 msgstr "Zuletzt aktualisiert von"
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__write_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__write_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__write_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__write_date
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__write_date
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__write_date
 msgid "Last Updated on"
 msgstr "Zuletzt aktualisiert am"
+
+#. module: commown_devices
+#: model:mail.channel,name:commown_devices.late_pickings_with_lots_channel
+msgid "Late pickings channel"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.actions.server,name:commown_devices.late_pickings_with_lots_cron_ir_actions_server
+#: model:ir.cron,cron_name:commown_devices.late_pickings_with_lots_cron
+#: model:ir.cron,name:commown_devices.late_pickings_with_lots_cron
+#: model:mail.template,subject:commown_devices.late_pickings_with_lots_mail
+msgid "Late pickings with lots"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__lead_id
@@ -211,7 +462,7 @@ msgid "Lead"
 msgstr "Interessent"
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/crm_lead.py:52
+#: code:addons/commown_devices/models/crm_lead.py:44
 #, python-format
 msgid "Lead has no assigned picking."
 msgstr ""
@@ -222,39 +473,162 @@ msgid "Lead/Opportunity"
 msgstr "Lead/Möglichkeit"
 
 #. module: commown_devices
+#: code:addons/commown_devices/models/stock_production_lot.py:35
+#, python-format
+msgid "Lot %s is already reserved"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/stock_production_lot.py:33
+#, python-format
+msgid "Lot %s not found in available stock"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_project_task__lot_id_domain
+msgid "Lot Id Domain"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_production_lot
 msgid "Lot/Serial"
 msgstr "Los/Serie"
 
 #. module: commown_devices
-#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_picking_form
+#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__lot_ids
+msgid "Lots"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_base_partner_merge_automatic_wizard
+msgid "Merge Partner Wizard"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/stock_move.py:53
+#, python-format
+msgid "More than one contract on move %s lots"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/product.py:59
+#, python-format
+msgid "More than one primary variant configured for %s with attributes %s"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__move_line_ids
+#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__move_line_view_ids
+msgid "Move Lines"
+msgstr ""
+
+#. module: commown_devices
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_device_picking_form
 msgid "Move involved device"
 msgstr ""
 
 #. module: commown_devices
-#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_crm_lead_picking_form
-#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_contract_transfer_form
-#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_inward_picking_form
-#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
-#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_picking_form
-msgid "OK"
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_involved_nonserial_picking_form
+msgid "Move involved nonserial product"
 msgstr ""
 
 #. module: commown_devices
-#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__picking_ids
-msgid "Pickings"
+#: code:addons/commown_devices/models/project_task.py:256
+#, python-format
+msgid "Move involved product"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__move_product_name
+msgid "Move product's name"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__link_line_ids
+msgid "Move to purchase_line link"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/common.py:65
+#, python-format
+msgid "Not enough %s under location(s) %s"
+msgstr ""
+
+#. module: commown_devices
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_crm_lead_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_picking_po_link_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_po_invoice_link_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_contract_transfer_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_device_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_involved_nonserial_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_inward_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_inward_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_outward_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_to_employee
+msgid "OK"
+msgstr "OK"
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__picking_id
+msgid "Picking"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__wizard_id
+msgid "Picking Po wizard"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/wizard_project_task_to_employee.py:66
+#, python-format
+msgid "Please set the task's partner before using this wizard"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/wizard_project_task_to_employee.py:69
+#, python-format
+msgid "Please use an employee as a partner"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__wizard_id
+msgid "Po invoice wizard"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__link_line_ids
+msgid "Po_line to invoice_line link"
 msgstr ""
 
 #. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__present_location_id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__present_location_id
 msgid "Present location of the product"
 msgstr ""
 
 #. module: commown_devices
-#: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__product_tmpl_id
+#: selection:product.service_storable_config,storable_type:0
+msgid "Primary product"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_product_product__primary_storable_variant_id
+msgid "Primary storable variant"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_product_product
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__variant_id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__variant_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__product_tmpl_id
 msgid "Product"
 msgstr "Produkt"
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_stock_move_line
+msgid "Product Moves (Stock Move Line)"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_product_template
@@ -262,9 +636,35 @@ msgid "Product Template"
 msgstr "Produktvorlage"
 
 #. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__product_location
+msgid "Product will be sent from"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__products_locations
+msgid "Products will be sent from"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_project
 msgid "Project"
 msgstr "Projekt"
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__purchase_line_id_domain
+msgid "Purchase Line Id Domain"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__po_id
+msgid "Purchase order"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__purchase_line_id
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_line__po_line_id
+msgid "Purchase order line"
+msgstr ""
 
 #. module: commown_devices
 #: model:ir.model,name:commown_devices.model_stock_quant
@@ -275,7 +675,7 @@ msgstr ""
 #: model:project.task.type,legend_done:commown_devices.diagnostic_stage
 #: model:project.task.type,legend_done:commown_devices.resiliated_stage
 msgid "Ready for Next Stage"
-msgstr ""
+msgstr "Bereit für die nächste Etappe"
 
 #. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_inward_picking_form
@@ -283,18 +683,59 @@ msgid "Receive a device"
 msgstr ""
 
 #. module: commown_devices
-#: model:project.task.type,name:commown_devices.resiliated_stage
-msgid "Resiliated stage"
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_inward_picking_form
+msgid "Receive a not tracked product"
 msgstr ""
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/project_task.py:187
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__attribute_value_ids
+msgid "Restrict to variants with following attribute values"
+msgstr ""
+
+#. module: commown_devices
+#: model:project.task.type,portal_displayed_name:commown_devices.resiliated_stage
+msgid "Résiliation traitée"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_stock_scrap
+msgid "Scrap"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/project_task.py:238
 #, python-format
 msgid "Scrap device"
 msgstr ""
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/crm_lead.py:33
+#: code:addons/commown_devices/models/stock_scrap.py:16
+#, python-format
+msgid "Scrap must be done to use this action"
+msgstr ""
+
+#. module: commown_devices
+#: selection:product.service_storable_config,storable_type:0
+msgid "Secondary product"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_product_product__secondary_storable_variant_ids
+msgid "Secondary storable variants"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_po_invoice_link_wizard__invoice_id
+msgid "Select invoice line from this invoice"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_picking_po_link_wizard__po_id
+msgid "Select purchase order line from this purchase order"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/crm_lead.py:29
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_crm_lead_picking_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
 #, python-format
@@ -302,9 +743,71 @@ msgid "Send a device"
 msgstr ""
 
 #. module: commown_devices
-#: model:ir.model.fields,field_description:commown_devices.field_product_product__storable_product_id
-#: model:ir.model.fields,field_description:commown_devices.field_product_template__storable_product_id
-msgid "Storable product"
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_outward_picking_form
+msgid "Send a not tracked product"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__prioritize_repackaged
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__prioritize_repackaged
+msgid "Send from repackaged devices if possible"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,help:commown_devices.field_project_task_to_employee_wizard__parcel_type
+msgid "Set this if you want to generate a shipping label at the same time"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__shipping_account_id
+msgid "Shipping account"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_stock_move_line__show_validate_picking
+msgid "Show Validate Picking"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__show_all_view_move_lines
+msgid "Show all move lines"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_stock_move
+#: model:ir.model.fields,field_description:commown_devices.field_contract_contract__move_ids
+msgid "Stock Move"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_move_po_link_line__move_id
+msgid "Stock move"
+msgstr ""
+
+#. module: commown_devices
+#: model_terms:ir.ui.view,arch_db:commown_devices.view_template_property_form
+msgid "Storable Configurations"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_project_task__storable_product_id_domain
+msgid "Storable Product Id Domain"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__storable_tmpl_id
+msgid "Storable Tmpl"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_product_service_storable_config__storable_variant_id
+msgid "Storable Variant"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_product_product__storable_config_ids
+#: model:ir.model.fields,field_description:commown_devices.field_product_template__storable_config_ids
+msgid "Storable configurations"
 msgstr ""
 
 #. module: commown_devices
@@ -312,28 +815,59 @@ msgstr ""
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_abstract_picking_wizard__task_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__task_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__task_id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_nonserial_product_picking_wizard__task_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__task_id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_inward_picking_wizard__task_id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_notracking_outward_picking_wizard__task_id
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__task_id
+#: model:ir.model.fields,field_description:commown_devices.field_project_task_to_employee_wizard__task_id
 msgid "Task"
 msgstr "Aufgabe"
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/crm_lead.py:22
+#: model:ir.model,name:commown_devices.model_project_task_type
+msgid "Task Stage"
+msgstr "Aufgabenstufe"
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/crm_lead.py:18
 #, python-format
-msgid "The contract has already assigned picking(s)!\n"
+msgid ""
+"The contract has already assigned picking(s)!\n"
 "Either cancel, scrap or validate it."
 msgstr ""
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/wizard_project_task_picking.py:86
+#: code:addons/commown_devices/models/project_task.py:203
+#, python-format
+msgid ""
+"These tasks can not be moved forward. There are no picking linked to those "
+"tasks: %s"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/project_task.py:175
+#, python-format
+msgid ""
+"These tasks can not be moved forward. There are still device(s) associated "
+"with their contract: %s"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/wizard_project_task_picking.py:88
+#: code:addons/commown_devices/models/wizard_project_task_picking.py:133
 #, python-format
 msgid "This action should not be used in resiliation project"
 msgstr ""
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/project_task.py:154
-#, python-format
-msgid "This task can not be moved forward. There are still %s device(s) associated with the contract"
+#: model:project.task.type,name:commown_devices.diagnostic_stage
+msgid "To be invoiced"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__lot_ids
+msgid "Tracked Devices"
 msgstr ""
 
 #. module: commown_devices
@@ -347,9 +881,14 @@ msgid "Transfer device to new contract"
 msgstr ""
 
 #. module: commown_devices
-#: code:addons/commown_devices/models/picking.py:16
+#: code:addons/commown_devices/models/stock_picking.py:35
 #, python-format
 msgid "Transfer must be done to use this action"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model.fields,help:commown_devices.field_project_task_to_employee_wizard__delivered_by_hand
+msgid "Unset if the device must be sent by post"
 msgstr ""
 
 #. module: commown_devices
@@ -359,14 +898,49 @@ msgid "Use for device tracking?"
 msgstr ""
 
 #. module: commown_devices
-#: model:ir.model.fields,field_description:commown_devices.field_crm_lead_picking_wizard__variant_id
+#: model_terms:ir.ui.view,arch_db:commown_devices.contract_contract_customer_form_view
+msgid "Validate"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__variant_id
 msgid "Variant"
 msgstr ""
 
 #. module: commown_devices
+#: model:ir.model,name:commown_devices.model_project_task_to_employee_wizard
+msgid "Wizard to give a device to an employee"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_picking_po_link_wizard
+msgid "Wizard to link picking to purchase order"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_po_invoice_link_wizard
+msgid "Wizard to link purchase order line to invoices lines"
+msgstr ""
+
+#. module: commown_devices
+#: code:addons/commown_devices/models/wizard_crm_lead_picking.py:113
+#, python-format
+msgid "You have to select a lot for each tracked product"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.filters,name:commown_devices.late_pickings_with_lots_filter
+msgid "[Commown] Late transfer with lots"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.actions.server,name:commown_devices.action_set_picking_date_done_to_scheduled
 msgid "[LOG] Force picking and move dates to picking scheduled date"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.actions.server,name:commown_devices.action_set_scrap_date_done_to_scheduled
+msgid "[LOG] Force scrap and move date to scrap scheduled date"
 msgstr ""
 
 #. module: commown_devices
@@ -380,8 +954,28 @@ msgid "[commown] Generate picking"
 msgstr ""
 
 #. module: commown_devices
-#: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_involved_device_picking
-msgid "[commown] REPAIR: Move involved device"
+#: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_hand_over_to_employee
+msgid "[commown] Hand over a device to an employee"
+msgstr ""
+
+#. module: commown_devices
+#: model:mail.template,name:commown_devices.late_pickings_with_lots_mail
+msgid "[commown] Late pickings with lots"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.actions.act_window,name:commown_devices.action_wizard_link_po_to_invoices
+msgid "[commown] Link PO lines to invoices lines"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.actions.act_window,name:commown_devices.action_wizard_link_picking_to_po
+msgid "[commown] Link Picking to Po"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.actions.server,name:commown_devices.action_wizard_project_task_involved_product_picking
+msgid "[commown] REPAIR: Move involved product"
 msgstr ""
 
 #. module: commown_devices
@@ -390,8 +984,18 @@ msgid "[commown] SUPPORT: Receive a device"
 msgstr ""
 
 #. module: commown_devices
+#: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_notracking_inward_picking
+msgid "[commown] SUPPORT: Receive a not tracked product"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_outward_picking
 msgid "[commown] SUPPORT: Send a device"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.actions.act_window,name:commown_devices.action_wizard_project_task_notracking_outward_picking
+msgid "[commown] SUPPORT: Send a not tracked product"
 msgstr ""
 
 #. module: commown_devices
@@ -400,20 +1004,17 @@ msgid "[commown] Scrap involved device"
 msgstr ""
 
 #. module: commown_devices
-#: model:ir.model.fields,field_description:commown_devices.field_project_task_abstract_picking_wizard__date
-#: model:ir.model.fields,field_description:commown_devices.field_project_task_contract_transfer_wizard__date
-#: model:ir.model.fields,field_description:commown_devices.field_project_task_involved_device_picking_wizard__date
-#: model:ir.model.fields,field_description:commown_devices.field_project_task_inward_picking_wizard__date
-#: model:ir.model.fields,field_description:commown_devices.field_project_task_outward_picking_wizard__date
-msgid "date"
-msgstr ""
-
-#. module: commown_devices
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_crm_lead_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_picking_po_link_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_po_invoice_link_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_contract_transfer_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_device_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_involved_nonserial_picking_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_inward_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_inward_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_notracking_outward_picking_form
 #: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_outward_picking_form
-#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_picking_form
+#: model_terms:ir.ui.view,arch_db:commown_devices.wizard_project_task_to_employee
 msgid "or"
 msgstr "oder"
 
@@ -428,7 +1029,16 @@ msgid "project.task.inward.picking.wizard"
 msgstr ""
 
 #. module: commown_devices
+#: model:ir.model,name:commown_devices.model_project_task_notracking_inward_picking_wizard
+msgid "project.task.notracking.inward.picking.wizard"
+msgstr ""
+
+#. module: commown_devices
+#: model:ir.model,name:commown_devices.model_project_task_notracking_outward_picking_wizard
+msgid "project.task.notracking.outward.picking.wizard"
+msgstr ""
+
+#. module: commown_devices
 #: model:ir.model,name:commown_devices.model_project_task_outward_picking_wizard
 msgid "project.task.outward.picking.wizard"
 msgstr ""
-

--- a/commown_devices/models/__init__.py
+++ b/commown_devices/models/__init__.py
@@ -15,3 +15,4 @@ from . import wizard_crm_lead_picking
 from . import wizard_link_picking_po
 from . import wizard_link_po_invoice
 from . import wizard_project_task_picking
+from . import wizard_project_task_to_employee

--- a/commown_devices/models/wizard_project_task_to_employee.py
+++ b/commown_devices/models/wizard_project_task_to_employee.py
@@ -30,6 +30,21 @@ class ProjectTaskDeviceToEmployeeWizard(models.TransientModel):
         default=True,
     )
 
+    shipping_account_id = fields.Many2one(
+        related="task_id.project_id.shipping_account_id",
+    )
+
+    parcel_type = fields.Many2one(
+        "commown.parcel.type",
+        string="Generate a shipping label",
+        help="Set this if you want to generate a shipping label at the same time",
+    )
+
+    @api.onchange("delivered_by_hand")
+    def onchange_reset_shipping_data_if_delivered_by_hand(self):
+        if self.delivered_by_hand:
+            self.parcel_type = False
+
     def _domain_lot_id(self):
         loc_avail = self.env.ref("commown_devices.stock_location_available_for_rent")
         quant_domain = [("location_id", "child_of", loc_avail.id)]
@@ -101,5 +116,8 @@ class ProjectTaskDeviceToEmployeeWizard(models.TransientModel):
                 "contract_id": contract.id,
             }
         )
+
+        if self.parcel_type:
+            self.task_id._print_parcel_labels(self.parcel_type)
 
         return contract

--- a/commown_devices/models/wizard_project_task_to_employee.py
+++ b/commown_devices/models/wizard_project_task_to_employee.py
@@ -1,0 +1,105 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class ProjectTaskDeviceToEmployeeWizard(models.TransientModel):
+    _name = "project.task.to.employee.wizard"
+    _description = "Wizard to give a device to an employee"
+
+    task_id = fields.Many2one(
+        "project.task",
+        string="Task",
+        required=True,
+    )
+
+    lot_id = fields.Many2one(
+        "stock.production.lot",
+        string="Device",
+        domain=lambda self: self._domain_lot_id(),
+        required=True,
+    )
+
+    date = fields.Datetime(
+        string="Date",
+        help="Defaults to now - To be set only to force a date",
+    )
+
+    delivered_by_hand = fields.Boolean(
+        "Delivered by hand",
+        help="Unset if the device must be sent by post",
+        default=True,
+    )
+
+    def _domain_lot_id(self):
+        loc_avail = self.env.ref("commown_devices.stock_location_available_for_rent")
+        quant_domain = [("location_id", "child_of", loc_avail.id)]
+        quants = (
+            self.env["stock.quant"]
+            .search(quant_domain)
+            .filtered(lambda q: q.quantity > q.reserved_quantity)
+        )
+        return [("id", "in", quants.mapped("lot_id").ids)]
+
+    @api.multi
+    def execute(self):
+        self.ensure_one()
+
+        # Consistency checks:
+
+        # - Partner must be an employee
+        if not self.task_id.partner_id:
+            raise UserError(_("Please set the task's partner before using this wizard"))
+
+        if self.task_id.partner_id.commercial_partner_id.id != 1:
+            raise UserError(_("Please use an employee as a partner"))
+
+        # - Device must be available for rent
+        loc_avail = self.env.ref("commown_devices.stock_location_available_for_rent")
+        quant_domain = [
+            ("location_id", "child_of", loc_avail.id),
+            ("lot_id", "=", self.lot_id.id),
+        ]
+        quants = (
+            self.env["stock.quant"]
+            .search(quant_domain)
+            .filtered(lambda q: q.quantity > q.reserved_quantity)
+        )
+        if len(quants) != 1:
+            raise UserError(_("Cannot find given device. Is it really available?"))
+
+        # Create the contract and send the device:
+
+        ct = self.env.ref("commown_devices.contract_template_to_employee")
+        partner = self.task_id.partner_id
+        pt = self.lot_id.product_id.product_tmpl_id
+        cname = _("%(product)s for %(partner)s")
+        contract = self.env["contract.contract"].create(
+            {
+                "name": cname % {"product": pt.name, "partner": partner.name},
+                "contract_template_id": ct.id,
+                "partner_id": partner.id,
+            }
+        )
+        contract._onchange_contract_template_id()
+
+        # Waiting for the effective delivery before starting the contract is not
+        # important here, so its simpler to do it at the given date:
+        dtime = self.date or fields.Datetime.now()
+        contract.date_start = dtime.date()
+        contract.send_devices(
+            self.lot_id,
+            {},
+            {},
+            date=dtime,
+            do_transfer=self.delivered_by_hand,
+        )
+
+        self.task_id.update(
+            {
+                "lot_id": self.lot_id.id,
+                "storable_product_id": self.lot_id.product_id.id,
+                "contract_id": contract.id,
+            }
+        )
+
+        return contract

--- a/commown_devices/models/wizard_project_task_to_employee.py
+++ b/commown_devices/models/wizard_project_task_to_employee.py
@@ -25,7 +25,7 @@ class ProjectTaskDeviceToEmployeeWizard(models.TransientModel):
     )
 
     delivered_by_hand = fields.Boolean(
-        "Delivered by hand",
+        "Delivered by hand?",
         help="Unset if the device must be sent by post",
         default=True,
     )

--- a/commown_devices/tests/__init__.py
+++ b/commown_devices/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_stock_scrap
 from . import test_wizard_crm_lead
 from . import test_wizard_po_invoice_link
 from . import test_wizard_picking_po_link
+from . import test_wizard_to_employee

--- a/commown_devices/tests/common.py
+++ b/commown_devices/tests/common.py
@@ -286,3 +286,33 @@ def create_lot_and_quant(env, lot_name, product, location):
         }
     )
     return lot
+
+
+class BaseWizardToEmployeeMixin:
+    def setUp(self):
+        super().setUp()
+        project = self.env["project.project"].create({"name": "Test"})
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": "Firsttest",
+                "lastname": "Lasttest",
+                "street": "8A rue Schertz",
+                "zip": "67200",
+                "city": "Strasbourg",
+                "country_id": self.env.ref("base.fr").id,
+                "email": "contact@commown.coop",
+                "mobile": "0601020304",
+                "parent_id": 1,
+            }
+        )
+
+        self.task = self.env["project.task"].create(
+            {"name": "test", "project_id": project.id, "partner_id": partner.id}
+        )
+
+    def get_wizard(self, **kwargs):
+        kwargs.setdefault("task_id", self.task.id)
+        kwargs.setdefault("delivered_by_hand", False)
+        wizard = self.env["project.task.to.employee.wizard"].create(kwargs)
+        wizard.onchange_reset_shipping_data_if_delivered_by_hand()
+        return wizard

--- a/commown_devices/tests/test_wizard_to_employee.py
+++ b/commown_devices/tests/test_wizard_to_employee.py
@@ -4,35 +4,18 @@ from odoo.exceptions import UserError
 
 from odoo.addons.commown_shipping.tests.common import BaseShippingTC
 
-from .common import create_lot_and_quant
+from .common import BaseWizardToEmployeeMixin, create_lot_and_quant
 
 
-class WizardProjectTaskToEmployeeTC(BaseShippingTC):
+class WizardToEmployeeTC(BaseWizardToEmployeeMixin, BaseShippingTC):
     def setUp(self):
         super().setUp()
-        project = self.env["project.project"].create(
+
+        self.task.project_id.update(
             {
-                "name": "Test",
                 "delivery_tracking": True,
                 "shipping_account_id": self.shipping_account.id,
             }
-        )
-        partner = self.env["res.partner"].create(
-            {
-                "firstname": "Firsttest",
-                "lastname": "Lasttest",
-                "street": "8A rue Schertz",
-                "zip": "67200",
-                "city": "Strasbourg",
-                "country_id": self.env.ref("base.fr").id,
-                "email": "contact@commown.coop",
-                "mobile": "0601020304",
-                "parent_id": 1,
-            }
-        )
-
-        self.task = self.env["project.task"].create(
-            {"name": "test", "project_id": project.id, "partner_id": partner.id}
         )
 
         new_dev_loc = self.env.ref("commown_devices.stock_location_new_devices")
@@ -47,14 +30,10 @@ class WizardProjectTaskToEmployeeTC(BaseShippingTC):
         )
 
     def get_wizard(self, **kwargs):
-        kwargs.setdefault("task_id", self.task.id)
         kwargs.setdefault("lot_id", self.lot.id)
-        kwargs.setdefault("delivered_by_hand", False)
         kwargs.setdefault("shipping_account_id", self.shipping_account.id)
         kwargs.setdefault("parcel_type", self.parcel_type.id)
-        wizard = self.env["project.task.to.employee.wizard"].create(kwargs)
-        wizard.onchange_reset_shipping_data_if_delivered_by_hand()
-        return wizard
+        return super().get_wizard(**kwargs)
 
     def test_delivered_by_hand_ok(self):
         contract = self.get_wizard(delivered_by_hand=True).execute()

--- a/commown_devices/tests/test_wizard_to_employee.py
+++ b/commown_devices/tests/test_wizard_to_employee.py
@@ -1,0 +1,78 @@
+from odoo.exceptions import UserError
+from odoo.tests.common import SavepointCase
+
+from .common import create_lot_and_quant
+
+
+class WizardProjectTaskToEmployeeTC(SavepointCase):
+    def setUp(self):
+        super().setUp()
+        pid = self.env["project.project"].create({"name": "Test"}).id
+        partner = self.env["res.partner"].create({"name": "p1", "parent_id": 1})
+
+        self.task = self.env["project.task"].create(
+            {"name": "test", "project_id": pid, "partner_id": partner.id}
+        )
+
+        new_dev_loc = self.env.ref("commown_devices.stock_location_new_devices")
+        self.loc = self.env["stock.location"].create(
+            {"name": "new_fp", "usage": "internal", "location_id": new_dev_loc.id}
+        )
+        pt = self.env["product.template"].create(
+            {"name": "FP3", "type": "product", "tracking": "serial"}
+        )
+        self.lot = create_lot_and_quant(
+            self.env, "fp3_1", pt.product_variant_id, self.loc
+        )
+
+    def get_wizard(self):
+        return self.env["project.task.to.employee.wizard"].create(
+            {"task_id": self.task.id, "lot_id": self.lot.id}
+        )
+
+    def test_ok(self):
+        contract = self.get_wizard().execute()
+
+        self.assertEqual(contract.lot_ids, self.lot)
+        self.assertEqual(contract.partner_id.name, "p1")
+        self.assertEqual(self.task.partner_id.name, "p1")
+        self.assertEqual(self.task.lot_id, self.lot)
+        self.assertEqual(self.task.contract_id, contract)
+        quant = (
+            self.env["stock.quant"]
+            .search([("lot_id", "=", self.lot.id)])
+            .filtered(lambda q: q.quantity > q.reserved_quantity)
+        )
+        self.assertEqual(quant.location_id.partner_id, self.task.partner_id)
+        self.assertEqual(
+            quant.location_id.location_id,
+            self.env.ref("stock.stock_location_customers"),
+        )
+
+    def test_lot_domain(self):
+        wizard = self.get_wizard()
+        self.assertEqual(self.lot.search(wizard._domain_lot_id()), self.lot)
+
+        lot2 = create_lot_and_quant(self.env, "fp3_2", self.lot.product_id, self.loc)
+        self.assertEqual(self.lot.search(wizard._domain_lot_id()), self.lot | lot2)
+
+    def test_error_device_not_available(self):
+        quant = self.env["stock.quant"].search([("lot_id", "=", self.lot.id)])
+        self.assertEqual(len(quant), 1)  # Test pre-requisite
+
+        quant.reserved_quantity = 1
+        with self.assertRaises(UserError) as err:
+            self.get_wizard().execute()
+        self.assertEqual(
+            err.exception.name, "Cannot find given device. Is it really available?"
+        )
+
+    def test_error_no_partner(self):
+        self.task.partner_id = False
+        with self.assertRaises(UserError) as err:
+            self.get_wizard().execute()
+
+    def test_error_not_an_employee(self):
+        self.task.partner_id = self.env.ref("base.partner_demo_portal").id
+        with self.assertRaises(UserError) as err:
+            self.get_wizard().execute()

--- a/commown_devices/views/wizard_project_task_to_employee.xml
+++ b/commown_devices/views/wizard_project_task_to_employee.xml
@@ -1,0 +1,25 @@
+<odoo>
+
+  <record id="wizard_project_task_to_employee" model="ir.ui.view">
+    <field name="name">[commown] Wizard to give a device to an employee</field>
+    <field name="model">project.task.to.employee.wizard</field>
+    <field name="arch" type="xml">
+      <form string="Give a device to an employee">
+        <sheet>
+          <group>
+            <field name="task_id" invisible="1"/>
+            <field name="lot_id"/>
+            <field name="date"/>
+            <field name="delivered_by_hand"/>
+          </group>
+        </sheet>
+        <footer>
+          <button name="execute" string="OK" class="btn-primary" type="object"/>
+          or
+          <button string="Cancel" class="btn-default" special="cancel"/>
+        </footer>
+      </form>
+    </field>
+  </record>
+
+</odoo>

--- a/commown_devices/views/wizard_project_task_to_employee.xml
+++ b/commown_devices/views/wizard_project_task_to_employee.xml
@@ -6,11 +6,15 @@
     <field name="arch" type="xml">
       <form string="Give a device to an employee">
         <sheet>
-          <group>
+          <group name="base">
             <field name="task_id" invisible="1"/>
             <field name="lot_id"/>
             <field name="date"/>
+          </group>
+          <group name="delivery">
             <field name="delivered_by_hand"/>
+            <field name="shipping_account_id" invisible="1"/>
+            <field name="parcel_type" attrs="{'invisible': ['|', ('delivered_by_hand', '=', True), ('shipping_account_id', '=', False)]}"/>
           </group>
         </sheet>
         <footer>

--- a/commown_shipping/__manifest__.py
+++ b/commown_shipping/__manifest__.py
@@ -20,7 +20,7 @@
         "web_ir_actions_act_multi",
     ],
     "external_dependencies": {
-        "bin": ["pdfjam", "pdftk"],
+        "bin": ["pdfjam", "pdfunite"],
         "python": ["requests_toolbelt"],
     },
     "data": [

--- a/commown_shipping/i18n/de.po
+++ b/commown_shipping/i18n/de.po
@@ -1,35 +1,46 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* commown_shipping
+# 	* commown_shipping
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-06 17:20+0000\n"
+"POT-Creation-Date: 2024-09-07 15:12+0000\n"
 "PO-Revision-Date: 2022-12-06 17:20+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: commown_shipping
-#: model:mail.template,body_html:commown_shipping.parcel_at_postoffice
-msgid "\n"
-"      <p>The parcel of this order is waiting at the postoffice.</p>\n"
-"      \n"
-"      "
-msgstr ""
-
-#. module: commown_shipping
 #: model:mail.template,subject:commown_shipping.parcel_at_postoffice
-msgid "${object.user_id.company_id.name} - Customer parcel waiting at the postoffice"
+msgid ""
+"${object.user_id.company_id.name} - Customer parcel waiting at the postoffice"
 msgstr ""
 
 #. module: commown_shipping
-#: code:addons/commown_shipping/models/colissimo_utils.py:74
+#: model:mail.template,body_html:commown_shipping.parcel_at_postoffice
+msgid ""
+"<p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida "
+"Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Le client est&nbsp;<b "
+"style=\"font-weight:bolder;font-style: initial; font-variant-ligatures: "
+"initial; font-variant-caps: initial; text-align: inherit; font-weight: bold;"
+"\">${object.partner_id.name}.</b></p><p style=\"margin:0px 0 1rem 0;font-"
+"size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, "
+"sans-serif;\"><b style=\"font-weight:bolder;font-style: initial; font-"
+"variant-ligatures: initial; font-variant-caps: initial; text-align: inherit; "
+"font-weight: bold;\"><br></b><span style=\"font-style: initial; font-variant-"
+"ligatures: initial; font-variant-caps: initial; font-weight: initial; text-"
+"align: inherit;\">Il a au maximum 10 jours pour le récupérer, s'assurer "
+"qu'il peut le faire avant que le colis ne nous revienne.</span></p>"
+msgstr ""
+
+#. module: commown_shipping
+#: code:addons/commown_shipping/models/colissimo_utils.py:93
 #, python-format
 msgid "A phone number is required to generate a Colissimo label!"
 msgstr ""
@@ -51,7 +62,7 @@ msgid "Address lines' length is limited to %s. Please fix."
 msgstr ""
 
 #. module: commown_shipping
-#: code:addons/commown_shipping/models/colissimo_utils.py:78
+#: code:addons/commown_shipping/models/colissimo_utils.py:97
 #, python-format
 msgid "An email is required to generate a Colissimo label!"
 msgstr ""
@@ -64,12 +75,6 @@ msgid "Automatic email on delivery"
 msgstr ""
 
 #. module: commown_shipping
-#: model:ir.cron,cron_name:commown_shipping.delivery_tracking_crm_lead
-#: model:ir.cron,cron_name:commown_shipping.delivery_tracking_project_task
-msgid "Base: Auto-vacuum internal data"
-msgstr "Basis: Auto-Vacuum für interne Daten"
-
-#. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_delivery_parent_mixin__default_perform_actions_on_delivery
 #: model:ir.model.fields,field_description:commown_shipping.field_crm_team__default_perform_actions_on_delivery
 #: model:ir.model.fields,field_description:commown_shipping.field_project_project__default_perform_actions_on_delivery
@@ -77,31 +82,47 @@ msgid "By default, perform actions on delivery"
 msgstr ""
 
 #. module: commown_shipping
+#: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_crm_lead_print_label_form
+#: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_project_task_print_label_form
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#. module: commown_shipping
 #: model:ir.model,name:commown_shipping.model_commown_track_delivery_mixin
 msgid "Class holding the fields and methods to track parcel delivery"
 msgstr ""
 
 #. module: commown_shipping
-#: code:addons/commown_shipping/models/shipping_mixin.py:161
+#: code:addons/commown_shipping/models/shipping_mixin.py:173
 #, python-format
-msgid "Colissimo error:\n"
+msgid ""
+"Colissimo error:\n"
 "%s"
+msgstr ""
+
+#. module: commown_shipping
+#: model:ir.model.fields,field_description:commown_shipping.field_crm_lead__commercial_partner_id
+msgid "Commercial Entity"
 msgstr ""
 
 #. module: commown_shipping
 #: model:ir.model,name:commown_shipping.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Kontakt"
 
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type__create_uid
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__create_uid
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__create_uid
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__create_uid
 msgid "Created by"
 msgstr "Erstellt von"
 
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type__create_date
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__create_date
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__create_date
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__create_date
 msgid "Created on"
 msgstr "Erstellt am:"
 
@@ -127,12 +148,6 @@ msgid "Delivery Date"
 msgstr "Liefertermin"
 
 #. module: commown_shipping
-#: code:addons/commown_shipping/models/crm_lead.py:65
-#, python-format
-msgid "Delivery address ambiguity: there is one on the sale and another on the partner. Please fill-in the recipient partner field to desambiguify."
-msgstr ""
-
-#. module: commown_shipping
 #: model_terms:ir.ui.view,arch_db:commown_shipping.crm_case_form_view_oppor
 #: model_terms:ir.ui.view,arch_db:commown_shipping.view_task_form2
 msgid "Delivery followup"
@@ -155,21 +170,26 @@ msgid "Delivery tracking"
 msgstr ""
 
 #. module: commown_shipping
+#: model:ir.cron,cron_name:commown_shipping.delivery_tracking_crm_lead
 #: model:ir.cron,name:commown_shipping.delivery_tracking_crm_lead
-msgid "Delivery tracking: crm.lead--disabled-by-openupgrade"
+msgid "Delivery tracking: crm.lead"
 msgstr ""
 
 #. module: commown_shipping
+#: model:ir.cron,cron_name:commown_shipping.delivery_tracking_project_task
 #: model:ir.cron,name:commown_shipping.delivery_tracking_project_task
-msgid "Delivery tracking: project.task--disabled-by-openupgrade"
+msgid "Delivery tracking: project.task"
 msgstr ""
 
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_delivery_parent_mixin__display_name
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type__display_name
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_abstract_print_label_wizard__display_name
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__display_name
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__display_name
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_mixin__display_name
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_parent_mixin__display_name
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__display_name
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_track_delivery_mixin__display_name
 msgid "Display Name"
 msgstr "Anzeigename"
@@ -212,20 +232,25 @@ msgstr ""
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_delivery_parent_mixin__id
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type__id
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_abstract_print_label_wizard__id
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__id
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__id
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_mixin__id
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_parent_mixin__id
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__id
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_track_delivery_mixin__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: commown_shipping
 #: model:ir.model.fields,help:commown_shipping.field_commown_shipping_mixin__recipient_partner_id
 #: model:ir.model.fields,help:commown_shipping.field_crm_lead__recipient_partner_id
 #: model:ir.model.fields,help:commown_shipping.field_project_task__recipient_partner_id
-msgid "If left empty, a delivery partner will be looked-up for specified partner:\n"
+msgid ""
+"If left empty, a delivery partner will be looked-up for specified partner:\n"
 "- for crm leads, the sale's delivery partner will be used;\n"
-"- for project tasks (support, etc.), odoo will try to find a delivery partner from the partner or its company."
+"- for project tasks (support, etc.), odoo will try to find a delivery "
+"partner from the partner or its company."
 msgstr ""
 
 #. module: commown_shipping
@@ -241,9 +266,12 @@ msgstr ""
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_delivery_parent_mixin____last_update
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type____last_update
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_abstract_print_label_wizard____last_update
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account____last_update
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard____last_update
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_mixin____last_update
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_parent_mixin____last_update
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard____last_update
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_track_delivery_mixin____last_update
 msgid "Last Modified on"
 msgstr "Zuletzt geändert am"
@@ -251,14 +279,24 @@ msgstr "Zuletzt geändert am"
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type__write_uid
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__write_uid
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__write_uid
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__write_uid
 msgid "Last Updated by"
 msgstr "Zuletzt aktualisiert von"
 
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type__write_date
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__write_date
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__write_date
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__write_date
 msgid "Last Updated on"
 msgstr "Zuletzt aktualisiert am"
+
+#. module: commown_shipping
+#: code:addons/commown_shipping/models/crm_lead.py:52
+#, python-format
+msgid "Lead has no expedition ref. Please fill it in."
+msgstr ""
 
 #. module: commown_shipping
 #: model:ir.model,name:commown_shipping.model_crm_lead
@@ -266,15 +304,34 @@ msgid "Lead/Opportunity"
 msgstr "Lead/Möglichkeit"
 
 #. module: commown_shipping
-#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__name
-msgid "Name"
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__shipping_ids
+msgid "Leads"
 msgstr ""
 
 #. module: commown_shipping
-#: code:addons/commown_shipping/models/delivery_mixin.py:97
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__name
+msgid "Name"
+msgstr "Name"
+
+#. module: commown_shipping
+#: code:addons/commown_shipping/models/delivery_mixin.py:122
 #, python-format
-msgid "No mail email template specified for %s (neither in current record nor its parent)"
+msgid ""
+"No mail email template specified for %s (neither in current record nor its "
+"parent)"
 msgstr ""
+
+#. module: commown_shipping
+#: code:addons/commown_shipping/models/shipping_mixin.py:66
+#, python-format
+msgid "No shipping account defined"
+msgstr ""
+
+#. module: commown_shipping
+#: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_crm_lead_print_label_form
+#: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_project_task_print_label_form
+msgid "OK"
+msgstr "OK"
 
 #. module: commown_shipping
 #: model:ir.model,name:commown_shipping.model_commown_shipping_parent_mixin
@@ -307,6 +364,9 @@ msgid "Parcel technical names must be unique."
 msgstr ""
 
 #. module: commown_shipping
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_abstract_print_label_wizard__parcel_type_id
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__parcel_type_id
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__parcel_type_id
 #: model:ir.model.fields,field_description:commown_shipping.field_product_product__shipping_parcel_type_id
 #: model:ir.model.fields,field_description:commown_shipping.field_product_template__shipping_parcel_type_id
 msgid "Parcel type"
@@ -327,6 +387,27 @@ msgstr ""
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__password_env_is_editable
 msgid "Password Env Is Editable"
+msgstr ""
+
+#. module: commown_shipping
+#: model:ir.model,name:commown_shipping.model_commown_shipping_abstract_print_label_wizard
+msgid "Print a Colissimo label (abstract class)"
+msgstr ""
+
+#. module: commown_shipping
+#: model:ir.model,name:commown_shipping.model_commown_shipping_lead_print_label_wizard
+msgid "Print a Colissimo label from a crm lead"
+msgstr ""
+
+#. module: commown_shipping
+#: model:ir.model,name:commown_shipping.model_commown_shipping_task_print_label_wizard
+msgid "Print a Colissimo label from a project task"
+msgstr ""
+
+#. module: commown_shipping
+#: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_crm_lead_print_label_form
+#: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_project_task_print_label_form
+msgid "Print label"
 msgstr ""
 
 #. module: commown_shipping
@@ -389,6 +470,11 @@ msgid "Task"
 msgstr "Aufgabe"
 
 #. module: commown_shipping
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__shipping_ids
+msgid "Tasks"
+msgstr "Aufgaben"
+
+#. module: commown_shipping
 #: sql_constraint:res.partner:0
 msgid "The street field size cannot exceed 35"
 msgstr ""
@@ -399,25 +485,30 @@ msgid "The weight must be > 0!"
 msgstr ""
 
 #. module: commown_shipping
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_abstract_print_label_wizard__use_full_page_per_label
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_lead_print_label_wizard__use_full_page_per_label
+#: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_task_print_label_wizard__use_full_page_per_label
+msgid "Use a full page per label"
+msgstr ""
+
+#. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type__weight
 msgid "Weight (kg)"
 msgstr ""
 
 #. module: commown_shipping
-#: model:ir.actions.server,name:commown_shipping.action_print_outward_fp2_label_issue
-#: model:ir.actions.server,name:commown_shipping.action_print_outward_fp2_label_task
-msgid "[commown] Print Fairphone parcel outward label(s)"
+#: model:ir.actions.act_window,name:commown_shipping.action_wizard_crm_lead_print_label
+msgid "[commown] Print label"
 msgstr ""
 
 #. module: commown_shipping
-#: model:ir.actions.server,name:commown_shipping.action_print_return_fp2_label_issue
-#: model:ir.actions.server,name:commown_shipping.action_print_return_fp2_label_task
-msgid "[commown] Print Fairphone parcel return label"
+#: model:ir.actions.act_window,name:commown_shipping.action_wizard_project_task_print_label
+msgid "[commown] SUPPORT,GESTION: print label"
 msgstr ""
 
 #. module: commown_shipping
-#: model:ir.actions.server,name:commown_shipping.action_print_outward_label_lead
-msgid "[commown] Étiquette aller Crosscall (<1kg, 300€)"
+#: model:mail.template,name:commown_shipping.parcel_at_postoffice
+msgid "[commown] Un colis attend le client au bureau de poste"
 msgstr ""
 
 #. module: commown_shipping
@@ -425,3 +516,11 @@ msgstr ""
 msgid "commown.delivery.parent.mixin"
 msgstr ""
 
+#. module: commown_shipping
+#: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_crm_lead_print_label_form
+#: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_project_task_print_label_form
+msgid "or"
+msgstr "oder"
+
+#~ msgid "Base: Auto-vacuum internal data"
+#~ msgstr "Basis: Auto-Vacuum für interne Daten"

--- a/commown_shipping/i18n/fr.po
+++ b/commown_shipping/i18n/fr.po
@@ -1,15 +1,16 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* commown_shipping
+# 	* commown_shipping
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-02 13:27+0000\n"
-"PO-Revision-Date: 2024-04-02 13:27+0000\n"
+"POT-Creation-Date: 2024-09-07 15:11+0000\n"
+"PO-Revision-Date: 2024-09-09 10:58+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -17,22 +18,35 @@ msgstr ""
 
 #. module: commown_shipping
 #: model:mail.template,subject:commown_shipping.parcel_at_postoffice
-msgid "${object.user_id.company_id.name} - Customer parcel waiting at the postoffice"
-msgstr "${object.user_id.company_id.name} - Un colis attend le client au bureau de poste"
+msgid ""
+"${object.user_id.company_id.name} - Customer parcel waiting at the postoffice"
+msgstr ""
+"${object.user_id.company_id.name} - Un colis attend le client au bureau de "
+"poste"
 
 #. module: commown_shipping
 #: model:mail.template,body_html:commown_shipping.parcel_at_postoffice
-msgid "\n"
-"      <p>The parcel of this order is waiting at the postoffice.</p>\n"
-"      \n"
-"      "
+msgid ""
+"<p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida "
+"Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Le client est&nbsp;<b "
+"style=\"font-weight:bolder;font-style: initial; font-variant-ligatures: "
+"initial; font-variant-caps: initial; text-align: inherit; font-weight: bold;"
+"\">${object.partner_id.name}.</b></p><p style=\"margin:0px 0 1rem 0;font-"
+"size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, "
+"sans-serif;\"><b style=\"font-weight:bolder;font-style: initial; font-"
+"variant-ligatures: initial; font-variant-caps: initial; text-align: inherit; "
+"font-weight: bold;\"><br></b><span style=\"font-style: initial; font-variant-"
+"ligatures: initial; font-variant-caps: initial; font-weight: initial; text-"
+"align: inherit;\">Il a au maximum 10 jours pour le récupérer, s'assurer "
+"qu'il peut le faire avant que le colis ne nous revienne.</span></p>"
 msgstr "<p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Le client est&nbsp;<b style=\"font-weight:bolder;font-style: initial; font-variant-ligatures: initial; font-variant-caps: initial; text-align: inherit; font-weight: bold;\">${object.partner_id.name}.</b></p><p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\"><b style=\"font-weight:bolder;font-style: initial; font-variant-ligatures: initial; font-variant-caps: initial; text-align: inherit; font-weight: bold;\"><br></b><span style=\"font-style: initial; font-variant-ligatures: initial; font-variant-caps: initial; font-weight: initial; text-align: inherit;\">Il a au maximum 10 jours pour le récupérer, s'assurer qu'il peut le faire avant que le colis ne nous revienne.</span></p>"
 
 #. module: commown_shipping
 #: code:addons/commown_shipping/models/colissimo_utils.py:93
 #, python-format
 msgid "A phone number is required to generate a Colissimo label!"
-msgstr "Un numéro de téléphone est requis pour générer une étiquette Colissimo !"
+msgstr ""
+"Un numéro de téléphone est requis pour générer une étiquette Colissimo !"
 
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__account
@@ -54,7 +68,8 @@ msgstr "Les lignes d'adresse sont limitées à %s caractères."
 #: code:addons/commown_shipping/models/colissimo_utils.py:97
 #, python-format
 msgid "An email is required to generate a Colissimo label!"
-msgstr "Une adresse électronique est requise pour générer une étiquette Colissimo !"
+msgstr ""
+"Une adresse électronique est requise pour générer une étiquette Colissimo !"
 
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_track_delivery_mixin__send_email_on_delivery
@@ -62,12 +77,6 @@ msgstr "Une adresse électronique est requise pour générer une étiquette Coli
 #: model:ir.model.fields,field_description:commown_shipping.field_project_task__send_email_on_delivery
 msgid "Automatic email on delivery"
 msgstr "Envoi automatique de l'email à la livraison"
-
-#. module: commown_shipping
-#: model:ir.cron,cron_name:commown_shipping.delivery_tracking_crm_lead
-#: model:ir.cron,cron_name:commown_shipping.delivery_tracking_project_task
-msgid "Base: Auto-vacuum internal data"
-msgstr "Base : données internes sur l'aspiration automatique"
 
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_delivery_parent_mixin__default_perform_actions_on_delivery
@@ -88,12 +97,19 @@ msgid "Class holding the fields and methods to track parcel delivery"
 msgstr "Classe portant les champs et méthodes de suivi des colis"
 
 #. module: commown_shipping
-#: code:addons/commown_shipping/models/shipping_mixin.py:166
+#: code:addons/commown_shipping/models/shipping_mixin.py:173
 #, python-format
-msgid "Colissimo error:\n"
+msgid ""
+"Colissimo error:\n"
 "%s"
-msgstr "Erreur Colissimo :\n"
+msgstr ""
+"Erreur Colissimo :\n"
 "%s"
+
+#. module: commown_shipping
+#: model:ir.model.fields,field_description:commown_shipping.field_crm_lead__commercial_partner_id
+msgid "Commercial Entity"
+msgstr "Entité commerciale"
 
 #. module: commown_shipping
 #: model:ir.model,name:commown_shipping.model_res_partner
@@ -138,12 +154,6 @@ msgid "Delivery Date"
 msgstr "Date de livraison"
 
 #. module: commown_shipping
-#: code:addons/commown_shipping/models/crm_lead.py:65
-#, python-format
-msgid "Delivery address ambiguity: there is one on the sale and another on the partner. Please fill-in the recipient partner field to desambiguify."
-msgstr "Adresse de livraison ambigüe : il y en a une sur la vente et une autre sur le partenaire. Merci de remplir le champ \"Adresse de livraison\" pour lever l'ambigüité."
-
-#. module: commown_shipping
 #: model_terms:ir.ui.view,arch_db:commown_shipping.crm_case_form_view_oppor
 #: model_terms:ir.ui.view,arch_db:commown_shipping.view_task_form2
 msgid "Delivery followup"
@@ -166,11 +176,13 @@ msgid "Delivery tracking"
 msgstr "Suivi d'expédition"
 
 #. module: commown_shipping
+#: model:ir.cron,cron_name:commown_shipping.delivery_tracking_crm_lead
 #: model:ir.cron,name:commown_shipping.delivery_tracking_crm_lead
 msgid "Delivery tracking: crm.lead"
 msgstr "Suivi colissimo : opportunités"
 
 #. module: commown_shipping
+#: model:ir.cron,cron_name:commown_shipping.delivery_tracking_project_task
 #: model:ir.cron,name:commown_shipping.delivery_tracking_project_task
 msgid "Delivery tracking: project.task"
 msgstr "Suivi colissimo : tâches"
@@ -240,12 +252,18 @@ msgstr "ID"
 #: model:ir.model.fields,help:commown_shipping.field_commown_shipping_mixin__recipient_partner_id
 #: model:ir.model.fields,help:commown_shipping.field_crm_lead__recipient_partner_id
 #: model:ir.model.fields,help:commown_shipping.field_project_task__recipient_partner_id
-msgid "If left empty, a delivery partner will be looked-up for specified partner:\n"
+msgid ""
+"If left empty, a delivery partner will be looked-up for specified partner:\n"
 "- for crm leads, the sale's delivery partner will be used;\n"
-"- for project tasks (support, etc.), odoo will try to find a delivery partner from the partner or its company."
-msgstr "Lorsque laissée vide, une adresse de livraison sera recherchée pour le partenaire de la carte :\n"
-"- pour les opportunités, l'adresse de livraison du bon de commande sera utilisée ;\n"
-"- pour les tâches (support, etc.), odoo cherchera un partenaire de livraison en partant du partenaire ou en remontant à sa société."
+"- for project tasks (support, etc.), odoo will try to find a delivery "
+"partner from the partner or its company."
+msgstr ""
+"Lorsque laissée vide, une adresse de livraison sera recherchée pour le "
+"partenaire de la carte :\n"
+"- pour les opportunités, l'adresse de livraison du bon de commande sera "
+"utilisée ;\n"
+"- pour les tâches (support, etc.), odoo cherchera un partenaire de livraison "
+"en partant du partenaire ou en remontant à sa société."
 
 #. module: commown_shipping
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_parcel_type__insurance_value
@@ -287,10 +305,12 @@ msgid "Last Updated on"
 msgstr "Dernière mise à jour le"
 
 #. module: commown_shipping
-#: code:addons/commown_shipping/models/crm_lead.py:59
+#: code:addons/commown_shipping/models/crm_lead.py:52
 #, python-format
 msgid "Lead has no expedition ref. Please fill it in."
-msgstr "L'opportunité n'a pas de numéro d'expédition. Remplissez le pour passer dans cette colonne"
+msgstr ""
+"L'opportunité n'a pas de numéro d'expédition. Remplissez le pour passer dans "
+"cette colonne"
 
 #. module: commown_shipping
 #: model:ir.model,name:commown_shipping.model_crm_lead
@@ -308,16 +328,20 @@ msgid "Name"
 msgstr "Nom"
 
 #. module: commown_shipping
+#: code:addons/commown_shipping/models/delivery_mixin.py:122
+#, python-format
+msgid ""
+"No mail email template specified for %s (neither in current record nor its "
+"parent)"
+msgstr ""
+"Aucun modèle de courriel paramétré pour %s (ni sur le doc courant ni sur son "
+"parent)"
+
+#. module: commown_shipping
 #: code:addons/commown_shipping/models/shipping_mixin.py:66
 #, python-format
 msgid "No shipping account defined"
 msgstr "Aucun compte de livraison défini"
-
-#. module: commown_shipping
-#: code:addons/commown_shipping/models/delivery_mixin.py:104
-#, python-format
-msgid "No mail email template specified for %s (neither in current record nor its parent)"
-msgstr "Aucun modèle de courriel paramétré pour %s (ni sur le doc courant ni sur son parent)"
 
 #. module: commown_shipping
 #: model_terms:ir.ui.view,arch_db:commown_shipping.wizard_crm_lead_print_label_form
@@ -380,11 +404,6 @@ msgstr "Valeur Env par défaut pour le mot de passe"
 #: model:ir.model.fields,field_description:commown_shipping.field_commown_shipping_account__password_env_is_editable
 msgid "Password Env Is Editable"
 msgstr "La valeur Env du mot de passe est éditable"
-
-#. module: commown_shipping
-#: model:ir.model,name:commown_shipping.model_project_task_print_label_wizard
-msgid "Print a Colissimo label"
-msgstr "Imprimer une étiquette colissimo"
 
 #. module: commown_shipping
 #: model:ir.model,name:commown_shipping.model_commown_shipping_abstract_print_label_wizard
@@ -504,6 +523,11 @@ msgid "[commown] SUPPORT,GESTION: print label"
 msgstr "[commown] SUPPORT,GESTION: imprimer une étiquette"
 
 #. module: commown_shipping
+#: model:mail.template,name:commown_shipping.parcel_at_postoffice
+msgid "[commown] Un colis attend le client au bureau de poste"
+msgstr "[commown] Un colis attend le client au bureau de poste"
+
+#. module: commown_shipping
 #: model:ir.model,name:commown_shipping.model_commown_delivery_parent_mixin
 msgid "commown.delivery.parent.mixin"
 msgstr "commown.delivery.parent.mixin"
@@ -514,3 +538,36 @@ msgstr "commown.delivery.parent.mixin"
 msgid "or"
 msgstr "ou"
 
+#~ msgid ""
+#~ "\n"
+#~ "      <p>The parcel of this order is waiting at the postoffice.</p>\n"
+#~ "      \n"
+#~ "      "
+#~ msgstr ""
+#~ "<p style=\"margin:0px 0 1rem 0;font-size:13px;font-family:&quot;Lucida "
+#~ "Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Le client est&nbsp;"
+#~ "<b style=\"font-weight:bolder;font-style: initial; font-variant-"
+#~ "ligatures: initial; font-variant-caps: initial; text-align: inherit; font-"
+#~ "weight: bold;\">${object.partner_id.name}.</b></p><p style=\"margin:0px 0 "
+#~ "1rem 0;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, "
+#~ "Verdana, Arial, sans-serif;\"><b style=\"font-weight:bolder;font-style: "
+#~ "initial; font-variant-ligatures: initial; font-variant-caps: initial; "
+#~ "text-align: inherit; font-weight: bold;\"><br></b><span style=\"font-"
+#~ "style: initial; font-variant-ligatures: initial; font-variant-caps: "
+#~ "initial; font-weight: initial; text-align: inherit;\">Il a au maximum 10 "
+#~ "jours pour le récupérer, s'assurer qu'il peut le faire avant que le colis "
+#~ "ne nous revienne.</span></p>"
+
+#~ msgid "Base: Auto-vacuum internal data"
+#~ msgstr "Base : données internes sur l'aspiration automatique"
+
+#~ msgid ""
+#~ "Delivery address ambiguity: there is one on the sale and another on the "
+#~ "partner. Please fill-in the recipient partner field to desambiguify."
+#~ msgstr ""
+#~ "Adresse de livraison ambigüe : il y en a une sur la vente et une autre "
+#~ "sur le partenaire. Merci de remplir le champ \"Adresse de livraison\" "
+#~ "pour lever l'ambigüité."
+
+#~ msgid "Print a Colissimo label"
+#~ msgstr "Imprimer une étiquette colissimo"

--- a/commown_shipping/models/crm_lead.py
+++ b/commown_shipping/models/crm_lead.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -31,14 +29,8 @@ class CrmLead(models.Model):
 
     @api.multi
     def _attachment_from_label(self, name, meta_data, label_data):
-        self.update(
-            {
-                "expedition_ref": meta_data["labelResponse"]["parcelNumber"],
-                "expedition_date": date.today(),
-                "delivery_date": False,
-            }
-        )
-        return super(CrmLead, self)._attachment_from_label(name, meta_data, label_data)
+        self.initialize_expedition_data(meta_data["labelResponse"]["parcelNumber"])
+        return super()._attachment_from_label(name, meta_data, label_data)
 
     @api.multi
     def parcel_labels(self, parcel_name=None, force_single=False):

--- a/commown_shipping/models/project_task.py
+++ b/commown_shipping/models/project_task.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class CommownProjectTask(models.Model):
@@ -15,3 +15,8 @@ class CommownProjectTask(models.Model):
     delivery_tracking = fields.Boolean(
         "Delivery tracking", related="project_id.delivery_tracking"
     )
+
+    @api.multi
+    def _attachment_from_label(self, name, meta_data, label_data):
+        self.initialize_expedition_data(meta_data["labelResponse"]["parcelNumber"])
+        return super()._attachment_from_label(name, meta_data, label_data)

--- a/commown_shipping/models/shipping_mixin.py
+++ b/commown_shipping/models/shipping_mixin.py
@@ -180,7 +180,7 @@ class CommownShippingMixin(models.AbstractModel):
         result_path = None
         try:
             run(
-                ["pdftk"] + paths + ["cat", "output", fpath],
+                ["pdfunite"] + paths + [fpath],
                 capture_output=True,
                 check=True,
             )

--- a/commown_shipping/tests/test_crm_lead.py
+++ b/commown_shipping/tests/test_crm_lead.py
@@ -44,6 +44,7 @@ class CrmLeadShippingTC(MockedEmptySessionMixin, BaseShippingTC):
         )
         team = self.env.ref("sales_team.salesteam_website_sales")
         team.shipping_account_id = self.shipping_account
+        team.delivery_tracking = True
 
         so = self.env["sale.order"].create(
             {

--- a/rental_fees/i18n/de.po
+++ b/rental_fees/i18n/de.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-07 13:01+0000\n"
-"PO-Revision-Date: 2024-02-14 08:53+0100\n"
+"POT-Creation-Date: 2024-09-07 15:12+0000\n"
+"PO-Revision-Date: 2024-09-09 10:53+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: \n"
@@ -88,13 +88,13 @@ msgstr "%(fixed_amount)s %(currency)s (fest)"
 #: code:addons/rental_fees/models/rental_fees_definition.py:317
 #, python-format
 msgid "%s is not fully delivered."
-msgstr ""
+msgstr "%s wurde nicht vollständig zugestellt."
 
 #. module: rental_fees
 #: code:addons/rental_fees/models/rental_fees_definition.py:306
 #, python-format
 msgid "%s is still in an early state."
-msgstr ""
+msgstr "%s befindet sich noch in einem wenig fortgeschrittenen Status."
 
 #. module: rental_fees
 #: model:ir.model,name:rental_fees.model_rental_fees_definition
@@ -165,7 +165,7 @@ msgid "Cannot add an excluded-from-fees PO to a fees definition"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:604
+#: code:addons/rental_fees/models/rental_fees_computation.py:596
 #, python-format
 msgid "Cannot reset fees computation if not in the 'done' state"
 msgstr ""
@@ -173,7 +173,7 @@ msgstr ""
 "im Zustand \"erledigt\" befindet."
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:608
+#: code:addons/rental_fees/models/rental_fees_computation.py:600
 #, python-format
 msgid "Cannot reset fees computation with a non-canceled invoice"
 msgstr ""
@@ -290,6 +290,12 @@ msgid "Device Domain"
 msgstr ""
 
 #. module: rental_fees
+#: code:addons/rental_fees/models/wizard_project_task_to_employee.py:27
+#, python-format
+msgid "Device used by an employee (%s)"
+msgstr "Von einem Mitarbeiter verwendetes Gerät (%s)"
+
+#. module: rental_fees
 #: code:addons/rental_fees/models/rental_fees_definition.py:259
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_definition_view_form
 #, python-format
@@ -366,13 +372,13 @@ msgid "Fees"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:493
+#: code:addons/rental_fees/models/rental_fees_computation.py:485
 #, python-format
 msgid "Fees computation details"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:507
+#: code:addons/rental_fees/models/rental_fees_computation.py:499
 #, python-format
 msgid "Fees computation job"
 msgstr ""
@@ -382,6 +388,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition_line__fees_definition_id
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_detail_view_search
 msgid "Fees definition"
+msgstr ""
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_computation.py:304
+#, python-format
+msgid "Fees definition %s (id %d) has no line."
 msgstr ""
 
 #. module: rental_fees
@@ -714,7 +726,7 @@ msgid "Number of unread messages"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:185
+#: code:addons/rental_fees/models/rental_fees_computation.py:180
 #, python-format
 msgid ""
 "Operation not allowed: there are later fees computations with invoices which "
@@ -724,16 +736,16 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_computation__partner_id
 msgid "Partner"
-msgstr ""
+msgstr "Partner"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:533
+#: code:addons/rental_fees/models/rental_fees_computation.py:525
 #, python-format
 msgid "Please set the invoice model on all fees definitions."
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:544
+#: code:addons/rental_fees/models/rental_fees_computation.py:536
 #, python-format
 msgid "Please use the same invoice model on all fees definition."
 msgstr ""
@@ -922,7 +934,7 @@ msgid ""
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:539
+#: code:addons/rental_fees/models/rental_fees_computation.py:531
 #, python-format
 msgid "There is a later invoice for the same fees definition"
 msgstr ""
@@ -997,6 +1009,11 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_excluded_device__with_compensation
 msgid "With compensation"
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model,name:rental_fees.model_project_task_to_employee_wizard
+msgid "Wizard to give a device to an employee"
 msgstr ""
 
 #. module: rental_fees

--- a/rental_fees/i18n/fr.po
+++ b/rental_fees/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-07 13:01+0000\n"
-"PO-Revision-Date: 2024-06-07 17:41+0200\n"
+"POT-Creation-Date: 2024-09-07 15:12+0000\n"
+"PO-Revision-Date: 2024-09-09 10:49+0200\n"
 "Last-Translator: <florent@commown.coop>\n"
 "Language-Team: Commown\n"
 "Language: French\n"
@@ -163,10 +163,12 @@ msgstr "B2C"
 #: code:addons/rental_fees/models/rental_fees_definition.py:170
 #, python-format
 msgid "Cannot add an excluded-from-fees PO to a fees definition"
-msgstr "Il n'est pas possible de rajouter un achat paramétré comme exclu du commissionnement"
+msgstr ""
+"Il n'est pas possible de rajouter un achat paramétré comme exclu du "
+"commissionnement"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:604
+#: code:addons/rental_fees/models/rental_fees_computation.py:596
 #, python-format
 msgid "Cannot reset fees computation if not in the 'done' state"
 msgstr ""
@@ -174,7 +176,7 @@ msgstr ""
 "l'état 'fait'"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:608
+#: code:addons/rental_fees/models/rental_fees_computation.py:600
 #, python-format
 msgid "Cannot reset fees computation with a non-canceled invoice"
 msgstr ""
@@ -294,6 +296,12 @@ msgid "Device Domain"
 msgstr "Domaine de sélection de l'appareil"
 
 #. module: rental_fees
+#: code:addons/rental_fees/models/wizard_project_task_to_employee.py:27
+#, python-format
+msgid "Device used by an employee (%s)"
+msgstr "Appareil utilisé par un.e employé.e (%s)"
+
+#. module: rental_fees
 #: code:addons/rental_fees/models/rental_fees_definition.py:259
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_definition_view_form
 #, python-format
@@ -375,13 +383,13 @@ msgid "Fees"
 msgstr "Frais"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:493
+#: code:addons/rental_fees/models/rental_fees_computation.py:485
 #, python-format
 msgid "Fees computation details"
 msgstr "Détails du calcul"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:507
+#: code:addons/rental_fees/models/rental_fees_computation.py:499
 #, python-format
 msgid "Fees computation job"
 msgstr "Job de calcul"
@@ -392,6 +400,12 @@ msgstr "Job de calcul"
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_detail_view_search
 msgid "Fees definition"
 msgstr "Définition des commissions"
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_computation.py:304
+#, python-format
+msgid "Fees definition %s (id %d) has no line."
+msgstr "La définition de commissions %s (id %d) n'a aucune ligne."
 
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_computation_detail__fees_definition_line_id
@@ -466,7 +480,9 @@ msgstr "Abonnés (Partenaires)"
 #. module: rental_fees
 #: model:ir.model.fields,help:rental_fees.field_purchase_order__exclude_from_fees
 msgid "Force exclusion from fees even if a matching fees definition exists"
-msgstr "Exclure de force du commissionnement même si une définition de commissions correspond"
+msgstr ""
+"Exclure de force du commissionnement même si une définition de commissions "
+"correspond"
 
 #. module: rental_fees
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_detail_view_search
@@ -737,7 +753,7 @@ msgid "Number of unread messages"
 msgstr "Nombre de messages non lus"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:185
+#: code:addons/rental_fees/models/rental_fees_computation.py:180
 #, python-format
 msgid ""
 "Operation not allowed: there are later fees computations with invoices which "
@@ -752,7 +768,7 @@ msgid "Partner"
 msgstr "Partenaire"
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:533
+#: code:addons/rental_fees/models/rental_fees_computation.py:525
 #, python-format
 msgid "Please set the invoice model on all fees definitions."
 msgstr ""
@@ -760,7 +776,7 @@ msgstr ""
 "commissions."
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:544
+#: code:addons/rental_fees/models/rental_fees_computation.py:536
 #, python-format
 msgid "Please use the same invoice model on all fees definition."
 msgstr ""
@@ -963,7 +979,7 @@ msgstr ""
 "modèle défini sur la définition des commissions, ou ajoutées manuellement."
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:539
+#: code:addons/rental_fees/models/rental_fees_computation.py:531
 #, python-format
 msgid "There is a later invoice for the same fees definition"
 msgstr ""
@@ -1044,6 +1060,11 @@ msgid "With compensation"
 msgstr "Avec pénalité"
 
 #. module: rental_fees
+#: model:ir.model,name:rental_fees.model_project_task_to_employee_wizard
+msgid "Wizard to give a device to an employee"
+msgstr "Utilitaire pour confier un appareil à un.e employé.e"
+
+#. module: rental_fees
 #: selection:rental_fees.definition_line,duration_unit:0
 msgid "Years"
 msgstr "Années"
@@ -1080,22 +1101,3 @@ msgid "[commown] Update fees definitions with the new POs"
 msgstr ""
 "[commown] Mettre à jour des définitions de commissions avec les nouveaux "
 "achats"
-
-#~ msgid "Ignoring fees def '%s', superseded by a more recent one."
-#~ msgstr ""
-#~ "La définition de commissions '%s' a été ignorée car remplacée par une "
-#~ "plus récente."
-
-#~ msgid "Explicitely excluded devices (with compensation)"
-#~ msgstr "Appareils exclus manuellement (avec pénalité)"
-
-#~ msgid "Please set the invoice model on the fees definition."
-#~ msgstr ""
-#~ "Il est nécessaire de paramétrer un modèle de facture sur la définition "
-#~ "des commissions"
-
-#~ msgid ""
-#~ "[${object.company_id.name}] Fees to be invoices as of ${object.until_date}"
-#~ msgstr ""
-#~ "[${object.company_id.name}] Facturation des commissions sur les loyers au "
-#~ "${object.until_date}"

--- a/rental_fees/i18n/rental_fees.pot
+++ b/rental_fees/i18n/rental_fees.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-07 13:01+0000\n"
-"PO-Revision-Date: 2024-06-07 13:01+0000\n"
+"POT-Creation-Date: 2024-09-07 15:12+0000\n"
+"PO-Revision-Date: 2024-09-07 15:12+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -127,13 +127,13 @@ msgid "Cannot add an excluded-from-fees PO to a fees definition"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:604
+#: code:addons/rental_fees/models/rental_fees_computation.py:596
 #, python-format
 msgid "Cannot reset fees computation if not in the 'done' state"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:608
+#: code:addons/rental_fees/models/rental_fees_computation.py:600
 #, python-format
 msgid "Cannot reset fees computation with a non-canceled invoice"
 msgstr ""
@@ -248,6 +248,12 @@ msgid "Device Domain"
 msgstr ""
 
 #. module: rental_fees
+#: code:addons/rental_fees/models/wizard_project_task_to_employee.py:27
+#, python-format
+msgid "Device used by an employee (%s)"
+msgstr ""
+
+#. module: rental_fees
 #: code:addons/rental_fees/models/rental_fees_definition.py:259
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_definition_view_form
 #, python-format
@@ -319,13 +325,13 @@ msgid "Fees"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:493
+#: code:addons/rental_fees/models/rental_fees_computation.py:485
 #, python-format
 msgid "Fees computation details"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:507
+#: code:addons/rental_fees/models/rental_fees_computation.py:499
 #, python-format
 msgid "Fees computation job"
 msgstr ""
@@ -335,6 +341,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_definition_line__fees_definition_id
 #: model_terms:ir.ui.view,arch_db:rental_fees.rental_fees_computation_detail_view_search
 msgid "Fees definition"
+msgstr ""
+
+#. module: rental_fees
+#: code:addons/rental_fees/models/rental_fees_computation.py:304
+#, python-format
+msgid "Fees definition %s (id %d) has no line."
 msgstr ""
 
 #. module: rental_fees
@@ -653,7 +665,7 @@ msgid "Number of unread messages"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:185
+#: code:addons/rental_fees/models/rental_fees_computation.py:180
 #, python-format
 msgid "Operation not allowed: there are later fees computations with invoices which amount would become invalid."
 msgstr ""
@@ -664,13 +676,13 @@ msgid "Partner"
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:533
+#: code:addons/rental_fees/models/rental_fees_computation.py:525
 #, python-format
 msgid "Please set the invoice model on all fees definitions."
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:544
+#: code:addons/rental_fees/models/rental_fees_computation.py:536
 #, python-format
 msgid "Please use the same invoice model on all fees definition."
 msgstr ""
@@ -852,7 +864,7 @@ msgid "The supplier invoices of the computed fees. Generated from the invoice mo
 msgstr ""
 
 #. module: rental_fees
-#: code:addons/rental_fees/models/rental_fees_computation.py:539
+#: code:addons/rental_fees/models/rental_fees_computation.py:531
 #, python-format
 msgid "There is a later invoice for the same fees definition"
 msgstr ""
@@ -925,6 +937,11 @@ msgstr ""
 #. module: rental_fees
 #: model:ir.model.fields,field_description:rental_fees.field_rental_fees_excluded_device__with_compensation
 msgid "With compensation"
+msgstr ""
+
+#. module: rental_fees
+#: model:ir.model,name:rental_fees.model_project_task_to_employee_wizard
+msgid "Wizard to give a device to an employee"
 msgstr ""
 
 #. module: rental_fees

--- a/rental_fees/models/__init__.py
+++ b/rental_fees/models/__init__.py
@@ -3,3 +3,4 @@ from . import account_invoice_line
 from . import purchase_order
 from . import rental_fees_computation
 from . import rental_fees_definition
+from . import wizard_project_task_to_employee

--- a/rental_fees/models/wizard_project_task_to_employee.py
+++ b/rental_fees/models/wizard_project_task_to_employee.py
@@ -1,0 +1,44 @@
+from odoo import _, api, models
+
+
+class ProjectTaskDeviceToEmployeeWizard(models.TransientModel):
+    _inherit = "project.task.to.employee.wizard"
+
+    @api.multi
+    def execute(self):
+        super().execute()
+        lot = self.lot_id
+        fees_def = self.env["rental_fees.definition"].search(
+            [
+                ("order_ids.order_line.move_ids.move_line_ids.lot_id", "=", lot.id),
+                ("product_template_id", "=", lot.product_id.product_tmpl_id.id),
+            ]
+        )
+
+        if fees_def:
+            assert len(fees_def) == 1, _("More than 1 fees def found for %s") % lot.name
+            if lot in fees_def.excluded_devices.mapped("device"):
+                info = _(
+                    "Device %(serial)s was already excluded from fees"
+                    " (in fees def id %(def_id)d)"
+                )
+            else:
+                info = _("Device %(serial)s excluded from fees in def id %(def_id)d")
+                context = {"lang": fees_def.partner_id.lang}  # Use fees partner lang
+                reason = _("Device used by employee %s")
+                self.env["rental_fees.excluded_device"].create(
+                    {
+                        "fees_definition_id": fees_def.id,
+                        "device": lot.id,
+                        "reason": reason % self.task_id.partner_id.firstname,
+                    },
+                )
+
+            self.env.user.notify_info(
+                info % {"serial": lot.name, "def_id": fees_def.id}
+            )
+
+        else:
+            self.env.user.notify_info(
+                "Device %s is not subject to fees as of now." % lot.name
+            )

--- a/rental_fees/tests/__init__.py
+++ b/rental_fees/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_rental_fees_computation
 from . import test_rental_fees_definition
+from . import test_wizard_to_employee

--- a/rental_fees/tests/test_wizard_to_employee.py
+++ b/rental_fees/tests/test_wizard_to_employee.py
@@ -1,0 +1,75 @@
+import json
+
+from odoo.addons.commown_devices.tests.common import BaseWizardToEmployeeMixin
+
+from .common import RentalFeesTC
+
+
+class WizardToEmployeeTC(BaseWizardToEmployeeMixin, RentalFeesTC):
+    def create_po_and_picking(self, *args, **kwargs):
+        "Override to set default receipt picking destination to available for rent"
+        rent_loc = self.env.ref("commown_devices.stock_location_available_for_rent")
+        loc = self.env["stock.location"].create(
+            {"name": "Test loc", "usage": "internal", "location_id": rent_loc.id},
+        )
+
+        self.env.ref("stock.picking_type_in").default_location_dest_id = loc.id
+        return super().create_po_and_picking(*args, **kwargs)
+
+    def get_wizard(self, **kwargs):
+        lot = self.env["stock.production.lot"].search([("name", "=", "N/S 1")])
+        kwargs.setdefault("lot_id", lot.id)
+        return super().get_wizard(**kwargs)
+
+    def get_infos(self, old_infos=None):
+        name = json.dumps(self.env.user.notify_info_channel_name)
+        objs = self.env["bus.bus"].search([("channel", "=", name)], order="id")
+        msgs = [json.loads(m)["message"] for m in objs.mapped("message")]
+        return msgs[len(old_infos or ()) :]
+
+    def test_give_concerned_by_fees_device_to_employee(self):
+        "Device given to an employee must be excluded from fees if concerned"
+
+        self.assertNotIn("N/S 1", self.fees_def.excluded_devices.mapped("device.name"))
+
+        old_infos = self.get_infos()
+        self.get_wizard().execute()
+        new_infos = self.get_infos(old_infos)
+
+        self.assertIn("N/S 1", self.fees_def.excluded_devices.mapped("device.name"))
+
+        self.assertEqual(
+            new_infos,
+            ["Device N/S 1 excluded from fees in def id %d" % self.fees_def.id],
+        )
+
+    def test_give_already_excluded_from_fees_device_to_employee(self):
+        "User giving a fees-excluded device to an employee is informed"
+
+        lot = self.env["stock.production.lot"].search([("name", "=", "N/S 1")])
+        self.env["rental_fees.excluded_device"].create(
+            {"fees_definition_id": self.fees_def.id, "device": lot.id, "reason": "test"}
+        )
+
+        old_infos = self.get_infos()
+        self.get_wizard().execute()
+        new_infos = self.get_infos(old_infos)
+
+        self.assertEqual(
+            new_infos,
+            [
+                "Device N/S 1 was already excluded from fees (in fees def id %d)"
+                % self.fees_def.id
+            ],
+        )
+
+    def test_give_not_concerned_by_fees_device_to_employee(self):
+        "User giving a device to an employee is informed when it's not subject to fees"
+
+        self.fees_def.order_ids = False
+
+        old_infos = self.get_infos()
+        self.get_wizard().execute()
+        new_infos = self.get_infos(old_infos)
+
+        self.assertEqual(new_infos, ["Device N/S 1 is not subject to fees as of now."])


### PR DESCRIPTION
We use a support ticket and a contract which partner is the employee to mimic the way we handle customers. That way, these devices should not be exceptions anymore and should be easier to manage.