### PR TITLE
[security] Do not perform important actions as someone else

### DIFF
--- a/urban_mine/models/project_task.py
+++ b/urban_mine/models/project_task.py
@@ -71,10 +71,6 @@ class ProjectTask(models.Model):
         report_name="urban_mine.report_autoinvoice",
     ):
 
-        # Use task's user to perform all actions: invoice, payment, a.s.o.
-        if self.user_id:
-            self = self.sudo(self.user_id)
-
         ref = self.env.ref
         product = ref("urban_mine.product").product_variant_id
 


### PR DESCRIPTION
Sudo was used abusively here and could be used to perform important actions (like payments) in the name of anyone as soon as you could assign that person to the task, which was highly dangerous and not justified in any ways...