### PR TITLE
[FIX] Shiftphone screen/protective film self-troubleshooting not showing

### DIFF
--- a/commown_self_troubleshooting/data/troubleshooting.xml
+++ b/commown_self_troubleshooting/data/troubleshooting.xml
@@ -118,7 +118,7 @@
       <field name="category_id" eval="ref('shiftphone-ts-cat')"/>
       <field name="website_page_id" eval="ref('shiftphone-screen-page')" />
       <field name="requires_contract" eval="True"/>
-      <field name="contract_domain">[("contract_template_id.name", "like", "SHIFT/%")]</field>
+      <field name="contract_domain">[("contract_template_id.name", "like", "SHIF/%")]</field>
     </record>
 
     <record id="gs-day-ts-item" model="commown_self_troubleshooting.item">


### PR DESCRIPTION
# Context and issue

The self-troubleshooting page "smartphone-screen" is a generic form that allows smartphone renters to signal that their screen or protective screen is broken or needs repairing.

However, when checking various customers' customer area, when seeing several of the Shiftphone renters, that very self troubleshooting was not displayed, despite having a dedicated troubleshooting already coded

# Source of the issue

When getting into the customer area, the module checks for each self-troubleshooting item if it corresponds to the customer's contracts - to do that, each item has a domain defined which is used to check the customer's active contracts if one or more matches.

However, the domain defined for the Shiftphone screen (in commown_self_troubleshooting/data/troubleshooting was wrongly defined : it searched contract models name beginning with `SHIFT/%` - however, the internal contracts for Shiftphone actually start with `SHIF/%` - so, even if a customer has an active and valid Shiftphone contract, the search domain won't catch them due to this typo

# Solution

I simply fixed the domain from `SHIFT/%` to `SHIF/%`, reinstalled the module when launching odoo ( `odoo-bin -i commown_self_troubleshooting` ), and the record associated with the self-troubleshooting's domain was corrected, and so the customer can see that self-troubleshooting in their customer area agin

# Improvement points

When checking the tests, I realized that there are no tests defined to check whether the Shiftphone's Self-troubleshooting is OK to browse - the reason for it might be that there are many smartphones models for which this generic screen troubleshooting might be applied for, and it might seem redundant to test it for each - however, as we saw in this case, this might catch whenever a self-troubleshooting had trouble being accessed