### PR TITLE
[colissimo] Parse all multipart subtypes, not only mixed

### DIFF
--- a/commown_shipping/models/colissimo_utils.py
+++ b/commown_shipping/models/colissimo_utils.py
@@ -177,7 +177,7 @@ def parse_multipart(http_resp):
 
 def parse_response(resp):
     ctype_main, _ctype_details = parse_header(resp.headers["Content-Type"])
-    if ctype_main == "multipart/mixed":
+    if ctype_main.startswith("multipart/"):
         return parse_multipart(resp)
     elif ctype_main == "application/json":
         return resp.json(), None


### PR DESCRIPTION
For some labels, Colissimo uses multipart/related which lead to a crash, although the response parsing function itself was able to handle it.

So we only test if the Content-Type header is a multipart one, not testing the subtype.