### PR TITLE
Use commercial_partner_id to match lines in mass reconciliation

### DIFF
--- a/commown/models/simple_reconciliation.py
+++ b/commown/models/simple_reconciliation.py
@@ -17,6 +17,8 @@ class CommownMassReconcileSimplePartner(models.TransientModel):
         """Same reconcile method as mass.reconcile.simple.partner but with a
         control of the maturity date gap between them: if the date difference
         is bigger than `max_reconcile_days_gap`, the moves won't be reconciled.
+
+        Also use commercial_partner_id instead of partner_id to match move lines.
         """
 
         max_reconcile_days_gap = self.env.context.get(
@@ -38,8 +40,11 @@ class CommownMassReconcileSimplePartner(models.TransientModel):
             date_1 = lines[count]["date_maturity"]
             if count and not count % 10:
                 _logger.info("Reconcile progress: %s/%s", count, len(lines))
+            cur_commercial_partner = lines[count]["commercial_partner_id"]
             for i in range(count + 1, len(lines)):
-                if lines[count][self._key_field] != lines[i][self._key_field]:
+                # Use commercial_partner_id to avoid non-reconciliations due to move
+                # partners being translated to commercial_partner_id during import:
+                if cur_commercial_partner != lines[i]["commercial_partner_id"]:
                     _logger.info(
                         "Stop searching - %d trial(s)" " (key field changed)", i - count
                     )
@@ -87,10 +92,19 @@ class CommownMassReconcileSimplePartner(models.TransientModel):
     @api.multi
     def _simple_order(self, *args, **kwargs):
         return (
-            "ORDER BY account_move_line.%s, " "account_move_line.date_maturity asc"
-        ) % self._key_field
+            "ORDER BY"
+            " res_partner.commercial_partner_id,"
+            " account_move_line.date_maturity asc"
+        )
 
     def _base_columns(self):
         cols = super(CommownMassReconcileSimplePartner, self)._base_columns()
         cols.append("account_move_line.date_maturity")
+        cols.append("res_partner.commercial_partner_id")
         return cols
+
+    def _from_query(self, *args, **kwargs):
+        "Add the res_partner table to join it and reach the commercial_partner_id"
+        _from = super()._from_query(*args, **kwargs)
+        _from += " JOIN res_partner ON (res_partner.id=account_move_line.partner_id) "
+        return _from

--- a/commown/tests/test_simple_reconciliation.py
+++ b/commown/tests/test_simple_reconciliation.py
@@ -10,6 +10,7 @@ class SimpleReconciliationTC(SavepointCase):
         partner1 = self.env.ref("base.res_partner_address_15")
         partner2 = self.env.ref("base.res_partner_address_28")
         self.assertEqual(partner1.commercial_partner_id, partner2.commercial_partner_id)
+        partner3 = self.env.ref("base.partner_demo_portal")
 
         self.account = self.env.ref("l10n_fr.1_pcg_5113")
 
@@ -45,6 +46,14 @@ class SimpleReconciliationTC(SavepointCase):
                 "date_maturity": date(2018, 1, 21),
                 "credit": 0,
                 "debit": 2,
+            },
+            {
+                "name": "Test aml 5",
+                "partner_id": partner3.id,
+                "account_id": self.account.id,
+                "date_maturity": date(2018, 5, 1),
+                "credit": 2,
+                "debit": 0,
             },
         ]
 

--- a/commown/tests/test_simple_reconciliation.py
+++ b/commown/tests/test_simple_reconciliation.py
@@ -1,54 +1,95 @@
 from datetime import date
 
-from mock import patch
-
-from odoo.tests.common import TransactionCase, at_install, post_install
+from odoo.tests.common import SavepointCase
 
 
-@at_install(False)
-@post_install(True)
-class SimpleReconciliationTC(TransactionCase):
+class SimpleReconciliationTC(SavepointCase):
     def setUp(self):
-        super(SimpleReconciliationTC, self).setUp()
-        self.lines = [
+        super().setUp()
+
+        partner1 = self.env.ref("base.res_partner_address_15")
+        partner2 = self.env.ref("base.res_partner_address_28")
+        self.assertEqual(partner1.commercial_partner_id, partner2.commercial_partner_id)
+
+        self.account = self.env.ref("l10n_fr.1_pcg_5113")
+
+        lines = [
             {
-                "id": 1,
-                "partner_id": 7,
+                "name": "Test aml 1",
+                "partner_id": partner1.id,
+                "account_id": self.account.id,
                 "date_maturity": date(2018, 1, 1),
                 "credit": 2,
                 "debit": 0,
             },
             {
-                "id": 2,
-                "partner_id": 7,
+                "name": "Test aml 2",
+                "partner_id": partner2.id,
+                "account_id": self.account.id,
                 "date_maturity": date(2018, 1, 10),
                 "credit": 2,
                 "debit": 0,
             },
             {
-                "id": 3,
-                "partner_id": 7,
+                "name": "Test aml 3",
+                "partner_id": partner2.id,
+                "account_id": self.account.id,
                 "date_maturity": date(2018, 1, 11),
                 "credit": 0,
                 "debit": 2,
             },
             {
-                "id": 4,
-                "partner_id": 7,
+                "name": "Test aml 4",
+                "partner_id": partner1.id,
+                "account_id": self.account.id,
                 "date_maturity": date(2018, 1, 21),
                 "credit": 0,
                 "debit": 2,
             },
         ]
 
+        journal = self.env.ref("slimpay_statements_autoimport.slimpay_journal")
+        self.move = self.env["account.move"].create(
+            {"name": "My move", "journal_id": journal.id}
+        )
+        aml = self.env["account.move.line"].with_context(check_move_validity=False)
+        for num, line in enumerate(lines):
+            line["move_id"] = self.move.id
+            aml.create(line)
+
+    def reconcile(self, method):
+        amr = self.env["account.mass.reconcile"].create(
+            {"name": "Test with method %s" % method, "account": self.account.id}
+        )
+        meth = self.env["account.mass.reconcile.method"].create(
+            {
+                "name": method,
+                "write_off": 0.0,
+                "date_base_on": "newest",
+                "task_id": amr.id,
+                "journal_id": self.move.journal_id.id,
+                "account_id": self.account.id,
+            }
+        )
+        amr.run_reconcile()
+        return amr.history_ids.reconcile_line_ids
+
+    def assertReconcilesEqual(self, res, *expected_aml_name_pairs):
+        actual_aml_name_pairs = tuple(
+            r.mapped("reconciled_line_ids.name")
+            for r in res.mapped("full_reconcile_id")
+        )
+        self.assertEqual(expected_aml_name_pairs, actual_aml_name_pairs)
+
     def test_without_max_reconcile_days_gap(self):
-        mrs = self.env["mass.reconcile.simple.partner"]
-        with patch.object(mrs, "_reconcile_lines", return_value=(True, "")):
-            res = mrs.rec_auto_lines_simple(self.lines)
-        self.assertEqual(res, [1, 3, 2, 4])
+        self.assertReconcilesEqual(
+            self.reconcile("mass.reconcile.simple.partner"),
+            ["Test aml 1", "Test aml 4"],
+            ["Test aml 2", "Test aml 3"],
+        )
 
     def test_with_max_reconcile_days_gap(self):
-        mrs = self.env["mass.reconcile.simple.partner_commown"]
-        with patch.object(mrs, "_reconcile_lines", return_value=(True, "")):
-            res = mrs.rec_auto_lines_simple(self.lines)
-        self.assertEqual(res, [2, 3])
+        self.assertReconcilesEqual(
+            self.reconcile("mass.reconcile.simple.partner_commown"),
+            ["Test aml 2", "Test aml 3"],
+        )


### PR DESCRIPTION
... instead of using partner_id. This allows more flexibility in B2B between the Slimpay mandate signee and the invoiced partner.

Also improve tests a lot by removing initial mock and using the full API. This had to be done to cover the overloaded methods in simple_reconciliation.py anyway.