### PR TITLE
12.0-imp-commown_self_troubleshooting-screwdriver_text_in_task_template

### DIFF
--- a/commown_self_troubleshooting/data/FP2/camera/issue_template.xml
+++ b/commown_self_troubleshooting/data/FP2/camera/issue_template.xml
@@ -13,8 +13,10 @@
               Il ressort que la
               caméra (<t t-esc="old_or_new"/> modèle) de mon FP2 doit être
               changée.
-            </p><br/>
-
+            </p>
+            <p t-if="screwdriver=='yes'">
+              J'ai également besoin d'un prêt de tournevis.
+            </p>
             <t t-call="commown_self_troubleshooting.display-shipping-information" />
           </t>
 

--- a/commown_self_troubleshooting/data/FP2/micro/issue_template.xml
+++ b/commown_self_troubleshooting/data/FP2/micro/issue_template.xml
@@ -9,7 +9,11 @@
       <t t-name="self-troubleshoot-issue-description-fp2-micro">
         <p t-if="action=='ship'">
           Après avoir effectué un auto-dépannage, il ressort que le module micro de mon FP2 doit être changé.
-        </p><br/>
+        </p>
+        <p t-if="screwdriver=='yes'">
+          J'ai également besoin d'un prêt de tournevis.
+        </p>
+        <br/>
         <p t-if="action=='wait-simcard'">
           je vous informe que je vais tester avec une autre carte SIM.
         </p>

--- a/commown_self_troubleshooting/data/FP3/display/issue_template.xml
+++ b/commown_self_troubleshooting/data/FP3/display/issue_template.xml
@@ -12,8 +12,10 @@
           <p>
           Il ressort que l'écran de mon FP3 doit être changé.
           </p>
+          <p t-if="screwdriver=='yes'">
+            J'ai également besoin d'un prêt de tournevis.
+          </p>
         </t>
-
         <p t-else="">
           Mon écran a un souci : Commown doit m'expédier un appareil (FP3 / FP3+)
         </p><br/>

--- a/commown_self_troubleshooting/data/Smartphone/screen/issue_template.xml
+++ b/commown_self_troubleshooting/data/Smartphone/screen/issue_template.xml
@@ -15,6 +15,9 @@
           <t t-else="">
             <t t-if="type_contrat=='me'">
               <p>Il ressort qu'un écran muni d'une protection doit m'être envoyé.</p>
+              <p t-if="screwdriver=='yes'">
+                J'ai également besoin d'un prêt de tournevis.
+              </p>
             </t>
             <t t-else="">
               <p>L'écran de mon appareil est cassé - il ressort qu'un nouvel appareil doit m'être envoyé.</p>

--- a/commown_self_troubleshooting/i18n/commown_self_troubleshooting.pot
+++ b/commown_self_troubleshooting/i18n/commown_self_troubleshooting.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-27 11:09+0000\n"
-"PO-Revision-Date: 2025-02-27 11:09+0000\n"
+"POT-Creation-Date: 2025-03-26 09:00+0000\n"
+"PO-Revision-Date: 2025-03-26 09:00+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1306,6 +1306,11 @@ msgstr ""
 #: model:ir.ui.view,website_meta_description:commown_self_troubleshooting.other
 #: model:website.page,website_meta_description:commown_self_troubleshooting.other-page
 msgid "J'ai une demande qui ne rentre dans aucune des cases précédentes !"
+msgstr ""
+
+#. module: commown_self_troubleshooting
+#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.issue-description-smartphone-screen
+msgid "J'ai également besoin d'un prêt de tournevis."
 msgstr ""
 
 #. module: commown_self_troubleshooting

--- a/commown_self_troubleshooting/i18n/de.po
+++ b/commown_self_troubleshooting/i18n/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-27 11:09+0000\n"
+"POT-Creation-Date: 2025-03-26 09:00+0000\n"
 "PO-Revision-Date: 2025-02-27 13:52+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
@@ -1533,6 +1533,11 @@ msgid "Fairphone 5"
 msgstr "Fairphone 5"
 
 #. module: commown_self_troubleshooting
+#: model:ir.model,name:commown_self_troubleshooting.model_commown_self_troubleshooting_screwdriver_data
+msgid "Fields related to a type of screwdriver."
+msgstr ""
+
+#. module: commown_self_troubleshooting
 #: model:project.task.type,description:commown_self_troubleshooting.stage_callback
 msgid ""
 "For cases where the customer has not responded to the ticket once, which "
@@ -1708,6 +1713,11 @@ msgid "J'ai une demande qui ne rentre dans aucune des cases précédentes !"
 msgstr "Ich habe eine Anfrage, die nicht zu den vorherigen Fällen gehört!"
 
 #. module: commown_self_troubleshooting
+#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.issue-description-smartphone-screen
+msgid "J'ai également besoin d'un prêt de tournevis."
+msgstr "Außerdem benötige ich einen Schraubenzieher als Leihgabe."
+
+#. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.step-manipulation-option
 msgid "Je manipule les modules en cas de panne"
 msgstr "Ich repariere die Module im Falle eines Defekts"
@@ -1876,8 +1886,8 @@ msgid ""
 "id=\"contract_name\"/>)\n"
 "                      est : <b id=\"contract_commitment_end_date\"/>."
 msgstr ""
-"Das Ende der Bindungsfrist des von Ihnen gewählten Vertrags (<b "
-"id=\"contract_name\"/>)\n"
+"Das Ende der Bindungsfrist des von Ihnen gewählten Vertrags (<b id="
+"\"contract_name\"/>)\n"
 "                      ist: <b id=\"contract_commitment_end_date\"/>."
 
 #. module: commown_self_troubleshooting

--- a/commown_self_troubleshooting/i18n/fr.po
+++ b/commown_self_troubleshooting/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-27 11:09+0000\n"
+"POT-Creation-Date: 2025-03-26 09:00+0000\n"
 "PO-Revision-Date: 2023-11-10 09:25+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
@@ -1459,6 +1459,11 @@ msgstr ""
 #: model:ir.ui.view,website_meta_description:commown_self_troubleshooting.other
 #: model:website.page,website_meta_description:commown_self_troubleshooting.other-page
 msgid "J'ai une demande qui ne rentre dans aucune des cases précédentes !"
+msgstr ""
+
+#. module: commown_self_troubleshooting
+#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.issue-description-smartphone-screen
+msgid "J'ai également besoin d'un prêt de tournevis."
 msgstr ""
 
 #. module: commown_self_troubleshooting

--- a/commown_self_troubleshooting/static/src/self_troubleshooting_tour.js
+++ b/commown_self_troubleshooting/static/src/self_troubleshooting_tour.js
@@ -461,7 +461,7 @@ odoo.define("commown_self_troubleshooting.tour_fp2_battery", function(require) {
       commonSteps.checkInputNamesMatchesUser,
       commonSteps.gotoNextStep,
       ...commonSteps.funcAddMoreInfo("text My display need to be replaced!"),
-      ...commonSteps.funcCreateAndCheckTicket("écran muni"),
+      ...commonSteps.funcCreateAndCheckTicket("prêt de tournevis"),
     ]
   );
 


### PR DESCRIPTION
# Context

As a recent feature of the self-troubleshooting, we've added a form that allows customers to ask for a loaned screwdriver if they require one for a repair.
However, the way it was communicated to the intern support team was deemed easily missable - indeed, it was indicated in the tags of a project task, which could be missed if skimmed by too fast.

# Feature

- This PR aims to add a conditional text in the template of newly created task tickets if the customer has chosen to borrow a screwdriver
- The test related to the tool usage has been changed in order to check for that text in the ticket description