### PR TITLE
Do not depend on l10_fr in account_move_slimpay_import

### DIFF
--- a/account_move_slimpay_import/__manifest__.py
+++ b/account_move_slimpay_import/__manifest__.py
@@ -18,7 +18,6 @@
     },
     "depends": [
         "account_move_base_import",
-        "l10n_fr",
     ],
     "data": [
         "data/partner.xml",

--- a/account_move_slimpay_import/data/account_journal.xml
+++ b/account_move_slimpay_import/data/account_journal.xml
@@ -12,7 +12,6 @@
       <field name="default_debit_account_id" ref="slimpay_bank_account"/>
       <field name="default_credit_account_id" ref="slimpay_bank_account"/>
       <field name="commission_account_id" ref="slimpay_supplier_account"/>
-      <field name="receivable_account_id" ref="l10n_fr.1_pcg_5113"/>
       <field name="partner_id" ref="slimpay_partner"/>
     </record>
 

--- a/account_move_slimpay_import/tests/test_account_journal.py
+++ b/account_move_slimpay_import/tests/test_account_journal.py
@@ -10,10 +10,20 @@ HERE = (Path(__file__) / "..").resolve()
 class AccountJournalTC(TransactionCase):
     def setUp(self):
         super().setUp()
-        journal = self.env.ref("account_move_slimpay_import.slimpay_journal")
+
         fname = "reporting_sample.csv"
         with open(HERE / fname, "rb") as fobj:
             csv_content = fobj.read()
+
+        journal = self.env.ref("account_move_slimpay_import.slimpay_journal")
+        account_receivable = self.env["account.account"].create(
+            {
+                "code": "TEST.RECE",
+                "name": "Test receivable",
+                "user_type_id": self.env.ref("account.data_account_type_liquidity").id,
+            }
+        )
+        journal.receivable_account_id = account_receivable
 
         self.importer = self.env["credit.statement.import"].create(
             {


### PR DESCRIPTION
This is not necessary as the Slimpay journal is not updatable and it may be used in other countries.

Tests now create an new account to associate Slimpay journal with.