### PR TITLE
16.0 mig crm stage email template

### DIFF
--- a/crm_stage_email_template/README.rst
+++ b/crm_stage_email_template/README.rst
@@ -1,0 +1,14 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+==========================
+ CRM stage email template
+==========================
+
+This module adds an optional mail template to crm stages. When this
+field is set on a stage, when a lead reaches this stage, the target
+email template is sent to the partner of the lead with a lead as the
+template record.
+
+This mimics the same functionality available on projects.

--- a/crm_stage_email_template/__init__.py
+++ b/crm_stage_email_template/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/crm_stage_email_template/__manifest__.py
+++ b/crm_stage_email_template/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2021 Commown SCIC (https://commown.coop)
+# @author: Florent Cayré
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'CRM stage email template',
+    'category': '',
+    'version': '12.0.1.0.0',
+    'author': "Commown SCIC",
+    'license': "AGPL-3",
+    'website': "https://commown.coop",
+    'depends': [
+        'crm',
+    ],
+    'data': [
+        'views/crm_stage.xml',
+    ],
+    'installable': True,
+}

--- a/crm_stage_email_template/__manifest__.py
+++ b/crm_stage_email_template/__manifest__.py
@@ -3,17 +3,17 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
-    'name': 'CRM stage email template',
-    'category': '',
-    'version': '12.0.1.0.0',
-    'author': "Commown SCIC",
-    'license': "AGPL-3",
-    'website': "https://commown.coop",
-    'depends': [
-        'crm',
+    "name": "CRM stage email template",
+    "category": "",
+    "version": "12.0.1.0.0",
+    "author": "Commown SCIC",
+    "license": "AGPL-3",
+    "website": "https://commown.coop",
+    "depends": [
+        "crm",
     ],
-    'data': [
-        'views/crm_stage.xml',
+    "data": [
+        "views/crm_stage.xml",
     ],
-    'installable': True,
+    "installable": True,
 }

--- a/crm_stage_email_template/__manifest__.py
+++ b/crm_stage_email_template/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "CRM stage email template",
     "category": "",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "author": "Commown SCIC",
     "license": "AGPL-3",
     "website": "https://commown.coop",

--- a/crm_stage_email_template/__manifest__.py
+++ b/crm_stage_email_template/__manifest__.py
@@ -8,7 +8,7 @@
     "version": "12.0.1.0.1",
     "author": "Commown SCIC",
     "license": "AGPL-3",
-    "website": "https://commown.coop",
+    "website": "https://github.com/commown/commown-odoo-addons",
     "depends": [
         "crm",
     ],

--- a/crm_stage_email_template/__manifest__.py
+++ b/crm_stage_email_template/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "CRM stage email template",
     "category": "",
-    "version": "12.0.1.0.1",
+    "version": "16.0.1.0.0",
     "author": "Commown SCIC",
     "license": "AGPL-3",
     "website": "https://github.com/commown/commown-odoo-addons",

--- a/crm_stage_email_template/migrations/12.0.1.0.0/openupgrade_analysis.txt
+++ b/crm_stage_email_template/migrations/12.0.1.0.0/openupgrade_analysis.txt
@@ -1,0 +1,4 @@
+---Models in module 'crm_stage_email_template'---
+---Fields in module 'crm_stage_email_template'---
+---XML records in module 'crm_stage_email_template'---
+---nothing has changed in this module--

--- a/crm_stage_email_template/migrations/12.0.1.0.0/openupgrade_analysis.txt
+++ b/crm_stage_email_template/migrations/12.0.1.0.0/openupgrade_analysis.txt
@@ -1,4 +1,0 @@
----Models in module 'crm_stage_email_template'---
----Fields in module 'crm_stage_email_template'---
----XML records in module 'crm_stage_email_template'---
----nothing has changed in this module--

--- a/crm_stage_email_template/models/__init__.py
+++ b/crm_stage_email_template/models/__init__.py
@@ -1,0 +1,2 @@
+from . import crm_lead
+from . import crm_stage

--- a/crm_stage_email_template/models/crm_lead.py
+++ b/crm_stage_email_template/models/crm_lead.py
@@ -2,14 +2,16 @@ from odoo import models, api
 
 
 class CrmLead(models.Model):
-    _inherit = 'crm.lead'
+    _inherit = "crm.lead"
 
     @api.multi
     def _track_template(self, tracking):
         res = super()._track_template(tracking)
         test_lead = self[0]
         changes, tracking_value_ids = tracking[test_lead.id]
-        if 'stage_id' in changes and test_lead.stage_id.mail_template_id:
-            res['stage_id'] = (test_lead.stage_id.mail_template_id,
-                               {'composition_mode': 'mass_mail'})
+        if "stage_id" in changes and test_lead.stage_id.mail_template_id:
+            res["stage_id"] = (
+                test_lead.stage_id.mail_template_id,
+                {"composition_mode": "mass_mail"},
+            )
         return res

--- a/crm_stage_email_template/models/crm_lead.py
+++ b/crm_stage_email_template/models/crm_lead.py
@@ -1,4 +1,4 @@
-from odoo import models, api
+from odoo import api, models
 
 
 class CrmLead(models.Model):

--- a/crm_stage_email_template/models/crm_lead.py
+++ b/crm_stage_email_template/models/crm_lead.py
@@ -1,0 +1,15 @@
+from odoo import models, api
+
+
+class CrmLead(models.Model):
+    _inherit = 'crm.lead'
+
+    @api.multi
+    def _track_template(self, tracking):
+        res = super()._track_template(tracking)
+        test_lead = self[0]
+        changes, tracking_value_ids = tracking[test_lead.id]
+        if 'stage_id' in changes and test_lead.stage_id.mail_template_id:
+            res['stage_id'] = (test_lead.stage_id.mail_template_id,
+                               {'composition_mode': 'mass_mail'})
+        return res

--- a/crm_stage_email_template/models/crm_lead.py
+++ b/crm_stage_email_template/models/crm_lead.py
@@ -10,8 +10,5 @@ class CrmLead(models.Model):
         test_lead = self[0]
         changes, tracking_value_ids = tracking[test_lead.id]
         if "stage_id" in changes and test_lead.stage_id.mail_template_id:
-            res["stage_id"] = (
-                test_lead.stage_id.mail_template_id,
-                {"composition_mode": "mass_mail"},
-            )
+            res["stage_id"] = test_lead.stage_id.mail_template_id, {}
         return res

--- a/crm_stage_email_template/models/crm_lead.py
+++ b/crm_stage_email_template/models/crm_lead.py
@@ -4,10 +4,10 @@ from odoo import models
 class CrmLead(models.Model):
     _inherit = "crm.lead"
 
-    def _track_template(self, tracking):
-        res = super()._track_template(tracking)
+    def _track_template(self, changes):
+        res = super()._track_template(changes)
         test_lead = self[0]
-        changes, tracking_value_ids = tracking[test_lead.id]
+
         if "stage_id" in changes and test_lead.stage_id.mail_template_id:
             res["stage_id"] = test_lead.stage_id.mail_template_id, {}
         return res

--- a/crm_stage_email_template/models/crm_lead.py
+++ b/crm_stage_email_template/models/crm_lead.py
@@ -1,10 +1,9 @@
-from odoo import api, models
+from odoo import models
 
 
 class CrmLead(models.Model):
     _inherit = "crm.lead"
 
-    @api.multi
     def _track_template(self, tracking):
         res = super()._track_template(tracking)
         test_lead = self[0]

--- a/crm_stage_email_template/models/crm_stage.py
+++ b/crm_stage_email_template/models/crm_stage.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import fields, models
 
 
 class CrmStage(models.Model):

--- a/crm_stage_email_template/models/crm_stage.py
+++ b/crm_stage_email_template/models/crm_stage.py
@@ -2,12 +2,14 @@ from odoo import models, fields
 
 
 class CrmStage(models.Model):
-    _inherit = 'crm.stage'
+    _inherit = "crm.stage"
 
     mail_template_id = fields.Many2one(
-        'mail.template',
-        string='Email Template',
-        domain=[('model', '=', 'crm.lead')],
-        help=('If set an email will be sent to the partner'
-              'when the lead reaches this step.'),
+        "mail.template",
+        string="Email Template",
+        domain=[("model", "=", "crm.lead")],
+        help=(
+            "If set an email will be sent to the partner"
+            "when the lead reaches this step."
+        ),
     )

--- a/crm_stage_email_template/models/crm_stage.py
+++ b/crm_stage_email_template/models/crm_stage.py
@@ -1,0 +1,13 @@
+from odoo import models, fields
+
+
+class CrmStage(models.Model):
+    _inherit = 'crm.stage'
+
+    mail_template_id = fields.Many2one(
+        'mail.template',
+        string='Email Template',
+        domain=[('model', '=', 'crm.lead')],
+        help=('If set an email will be sent to the partner'
+              'when the lead reaches this step.'),
+    )

--- a/crm_stage_email_template/tests/__init__.py
+++ b/crm_stage_email_template/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_crm_stage_email_template

--- a/crm_stage_email_template/tests/test_crm_stage_email_template.py
+++ b/crm_stage_email_template/tests/test_crm_stage_email_template.py
@@ -1,0 +1,55 @@
+from odoo.tests import TransactionCase
+
+
+class TestCrmStageEmailTemplate(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Template
+        cls.test_template = cls.env["mail.template"].create(
+            {
+                "name": "Test template",
+            }
+        )
+
+        # Lead
+        cls.test_lead = cls.env["crm.lead"].create(
+            {
+                "name": "Test lead",
+                "type": "lead",
+            }
+        )
+
+    def test_crm_stage_w_template_id(self):
+        # Templates when stage_id is False (= No stage)
+        self.assertEqual({}, self.test_lead._track_template(["stage_id"]))
+
+        stage_w_template = self.env["crm.stage"].create(
+            {
+                "name": "Stage with template",
+                "mail_template_id": self.test_template.id,
+            }
+        )
+
+        self.test_lead.stage_id = stage_w_template.id
+
+        # Templates when no stage_id changes
+        self.assertEqual({}, self.test_lead._track_template(["type"]))
+
+        # Templates when stage_id changes
+        templates_stage_change = self.test_lead._track_template(["stage_id"])
+        self.assertIn("stage_id", templates_stage_change.keys())
+        self.assertEqual(self.test_template, templates_stage_change["stage_id"][0])
+
+    def test_crm_stage_w_out_template_id(self):
+        stage_w_out_template = self.env["crm.stage"].create(
+            {
+                "name": "Stage without template",
+            }
+        )
+        self.assertFalse(stage_w_out_template.mail_template_id)
+
+        self.test_lead.stage_id = stage_w_out_template.id
+
+        # Templates when stage_id.mail_template_id is False
+        self.assertEqual({}, self.test_lead._track_template(["stage_id"]))

--- a/crm_stage_email_template/views/crm_stage.xml
+++ b/crm_stage_email_template/views/crm_stage.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record model="ir.ui.view" id="task_type_edit">
+    <field name="name">crm.stage.form</field>
+    <field name="model">crm.stage</field>
+    <field name="inherit_id" ref="crm.crm_stage_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='team_id']" position="after">
+        <field name="mail_template_id"/>
+      </xpath>
+    </field>
+  </record>
+
+</odoo>

--- a/crm_stage_email_template/views/crm_stage.xml
+++ b/crm_stage_email_template/views/crm_stage.xml
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
   <record model="ir.ui.view" id="task_type_edit">
     <field name="name">crm.stage.form</field>
     <field name="model">crm.stage</field>
-    <field name="inherit_id" ref="crm.crm_stage_form"/>
+    <field name="inherit_id" ref="crm.crm_stage_form" />
     <field name="arch" type="xml">
       <xpath expr="//field[@name='team_id']" position="after">
-        <field name="mail_template_id"/>
+        <field name="mail_template_id" />
       </xpath>
     </field>
   </record>

--- a/setup/crm_stage_email_template/odoo/addons/crm_stage_email_template
+++ b/setup/crm_stage_email_template/odoo/addons/crm_stage_email_template
@@ -1,0 +1,1 @@
+../../../../crm_stage_email_template

--- a/setup/crm_stage_email_template/setup.py
+++ b/setup/crm_stage_email_template/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Noticable change : the `_track_template` method from `mail.thread` now takes as argument `changes`, a list containing all changed tracked fields for a given record (replacing `tracking`, a dict containing changed tracked fields for several modified records) 