### PR TITLE
Do not use wizard 'usage' related field in methods called from onchange

### DIFF
--- a/commown_devices/models/wizard_to_customer_picking.py
+++ b/commown_devices/models/wizard_to_customer_picking.py
@@ -84,7 +84,7 @@ class PickingToCustomerWizard(models.AbstractModel):
         """
         ref = self.env.ref
 
-        if self.usage == "internal":
+        if self.entity_id.contract_id.stock_ownership == "internal":
             loc_new = ref("commown_devices.stock_location_modules_and_accessories")
             loc_repack = ref("commown_devices.stock_repackaged_modules_and_accessories")
             if self.prioritize_repackaged:


### PR DESCRIPTION
In 12.0 it simply does not work and return False for permission-related (bad) reasons it seems. Note that in onchange, the entity is a NewId, which might be the cause of the bug.

Also note that in 12.0, we cannot explicitely set permissions on transient models (like the concerned crm.lead.to.customer.wizard), which changed in 16.0 so this should work in 16.0.