### PR TITLE
Allow customer team manager to set is_company=False when creating partners

### DIFF
--- a/customer_team_manager/models/res_partner.py
+++ b/customer_team_manager/models/res_partner.py
@@ -123,6 +123,10 @@ class ResPartner(models.Model):
         if vals.get("parent_id", False) == self.env.user.commercial_partner_id.id:
             allowed.add("parent_id")
 
+        # Allow setting is_company to False (which the create form might do)
+        if vals.get("is_company", True) is False:
+            allowed.add("is_company")
+
         if vals.get("company_name", True) is False:
             allowed.add("company_name")
 


### PR DESCRIPTION
The create form may pass this field and it should not crash the partner's creation, unless it is True (customers must not create other companies).