### PR TITLE
Fix compensation price for devices billed in several instalments

### DIFF
--- a/rental_fees/models/rental_fees_definition.py
+++ b/rental_fees/models/rental_fees_definition.py
@@ -245,8 +245,10 @@ class RentalFeesDefinition(models.Model):
             )
             raise UserError(msg % {"serial": device.name, "po": po_line.order_id.name})
 
-        mean_price_unit = sum(il.price_unit * il.quantity for il in inv_lines) / sum(
-            inv_lines.mapped("quantity")
+        mean_price_unit = sum(il.price_unit * il.quantity for il in inv_lines) / len(
+            po_line.mapped("move_ids.move_line_ids").filtered(
+                lambda mol: mol.state == "done"
+            )
         )
         return {
             "purchase": mean_price_unit,


### PR DESCRIPTION
When a 2nd bill contains additional charges for the same device, we need to compute the mean unit price by adding-up paid (billed) amounts divided by the number of devices that have been delivered.