### PR TITLE
[16.0][IMP] commown_automated_control : Add delete_last_line to base.automation model based on ir.actions.server

### DIFF
--- a/commown_automated_control/models/base_automation.py
+++ b/commown_automated_control/models/base_automation.py
@@ -20,3 +20,6 @@ class BaseAutomation(models.Model):
     def _compute_automated_contol_id(self):
         for rec in self.filtered("automated_control_ids"):
             rec.automated_control_id = rec.automated_control_ids[0]
+
+    def delete_last_line(self):
+        self.action_server_id.delete_last_line()


### PR DESCRIPTION
In the OCA module server_action_navigate, a method is inserted in the 'ir.actions.server' model, which is then used in their overload of the ir.actions.server form view.

However, the base.automation model, while possessing the fields of ir.actions.server (through the action_server_id attribute), does not possess a copy of this method. And since the base.automation form view is based on the ir.actions.server form view, having both server_action_navigate and base_automation installed leads to a view error, since the view validation tries to fetch the delete_last_line methode from base.automation.

As such, we add this simple method which calls delete_last_line through action_server_id.