### PR TITLE
[16.0][FIX] product_rental : Price display of product for recurrent prices

### DIFF
--- a/product_rental/views/website_sale_templates.xml
+++ b/product_rental/views/website_sale_templates.xml
@@ -17,7 +17,7 @@
   </template>
 
   <template id="products_item" inherit_id="website_sale.products_item">
-    <xpath expr="//div[@itemprop='offers']/t" position="after">
+    <xpath expr="//div[@itemprop='offers']" position="after">
       <b t-if="product.has_recurrent_payment">
         <span>From</span>
         <span
@@ -33,7 +33,9 @@
         <t>$0</t>
       </t>
     </xpath>
-    <xpath expr="//div[@itemprop='offers']/b" t-if="False" />
+    <xpath expr="//div[@itemprop='offers']" position="attributes">
+      <attribute name="t-if">False</attribute>
+    </xpath>
 
   </template>
 

--- a/product_rental/views/website_sale_templates.xml
+++ b/product_rental/views/website_sale_templates.xml
@@ -26,11 +26,15 @@
                 />
         <span t-field="product.recurrent_payment_frequency" />
       </b>
-      <t t-else="">
+      <t t-elif="template_price_vals['price_reduce'] > 0">
         <span
                     t-if="product.product_variant_count > 1 and product._get_combination_info()['price']"
                 >From</span>
-        <t>$0</t>
+        <span
+                    class="h6 mb-0"
+                    t-esc="template_price_vals['price_reduce']"
+                    t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+                />
       </t>
     </xpath>
     <xpath expr="//div[@itemprop='offers']" position="attributes">

--- a/product_rental/views/website_sale_templates.xml
+++ b/product_rental/views/website_sale_templates.xml
@@ -18,24 +18,31 @@
 
   <template id="products_item" inherit_id="website_sale.products_item">
     <xpath expr="//div[@itemprop='offers']" position="after">
-      <b t-if="product.has_recurrent_payment">
-        <span>From</span>
-        <span
-                    t-esc="product.recurrent_payment_amount"
-                    t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
-                />
-        <span t-field="product.recurrent_payment_frequency" />
-      </b>
-      <t t-elif="template_price_vals['price_reduce'] > 0">
-        <span
-                    t-if="product.product_variant_count > 1 and product._get_combination_info()['price']"
-                >From</span>
-        <span
-                    class="h6 mb-0"
-                    t-esc="template_price_vals['price_reduce']"
-                    t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
-                />
-      </t>
+      <div
+                class="product_price"
+                itemprop="offers"
+                itemscope="itemscope"
+                itemtype="http://schema.org/Offer"
+            >
+        <b t-if="product.has_recurrent_payment">
+          <span>From</span>
+          <span
+                        t-esc="product.recurrent_payment_amount"
+                        t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+                    />
+          <span t-field="product.recurrent_payment_frequency" />
+        </b>
+        <t t-elif="template_price_vals['price_reduce'] > 0">
+          <span
+                        t-if="product.product_variant_count > 1 and product._get_combination_info()['price']"
+                    >From</span>
+          <span
+                        class="h6 mb-0"
+                        t-esc="template_price_vals['price_reduce']"
+                        t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+                    />
+        </t>
+      </div>
     </xpath>
     <xpath expr="//div[@itemprop='offers']" position="attributes">
       <attribute name="t-if">False</attribute>


### PR DESCRIPTION
# Current visual

<img width="1556" height="694" alt="Capture d’écran du 2025-11-04 09-39-44" src="https://github.com/user-attachments/assets/fe32f954-68fd-4e6f-b42d-e07a351add56" />
<img width="1131" height="688" alt="Capture d’écran du 2025-11-04 09-40-18" src="https://github.com/user-attachments/assets/9a5b2f2d-219a-47dd-a23b-a34618c8dc65" />


# Visual after PR modifications

<img width="1556" height="694" alt="Capture d’écran du 2025-11-04 09-37-30" src="https://github.com/user-attachments/assets/d452bfea-5add-47e8-ad4a-1f4c7f893ab9" />
<img width="1131" height="688" alt="Capture d’écran du 2025-11-04 09-42-16" src="https://github.com/user-attachments/assets/27a6d27b-762f-4b07-ae6a-b2c42d25f339" />

