### PR TITLE
[16.0][IMP] commown_contractual_issue : Made contractual_issue_date required on contractual issue tasks

### DIFF
--- a/commown_contractual_issue/tests/test_project_task.py
+++ b/commown_contractual_issue/tests/test_project_task.py
@@ -1,4 +1,5 @@
-from odoo.tests.common import TransactionCase
+from odoo.fields import Date
+from odoo.tests.common import Form, TransactionCase
 
 
 class ProjectTaskTC(TransactionCase):
@@ -14,9 +15,9 @@ class ProjectTaskTC(TransactionCase):
         self.contract = self.env["contract.contract"].create(
             {"name": "Test contract", "partner_id": self.part_with_contract.id}
         )
-        project = self.env.ref("project.project_project_1")
+        self.project = self.env.ref("project.project_project_1")
         self.task = self.env["project.task"].create(
-            {"name": "Test task", "project_id": project.id, "partner_id": False}
+            {"name": "Test task", "project_id": self.project.id, "partner_id": False}
         )
 
         self.assertFalse(self.task.contract_id)
@@ -49,3 +50,43 @@ class ProjectTaskTC(TransactionCase):
         self.part_with_contract.is_company = True
         self.task.onchange_contract_id_set_partner()
         self.assertFalse(self.task.partner_id)
+
+    def test_contractual_issue_date_required_from_view(self):
+        """
+        When modifying a task with contractual issue tracking through the view,
+        the contractual_issue_date field should be required.
+        """
+        self.task.contractual_issue_date = False
+
+        # Case 1: contractual_issues_tracking is off
+        self.project.contractual_issues_tracking = False
+
+        f1 = Form(self.task)
+        f1.description = "This should pass"
+        f1.save()
+
+        self.assertFalse(self.task.contractual_issue_date)
+
+        # Case 2: contractual_issues_tracking is on
+        self.task.contract_id = self.contract
+
+        self.project.require_contract = True
+        self.project.contractual_issues_tracking = True
+
+        f2 = Form(self.task)
+
+        # Leaving contractual_issue_date unassigned should lead to an error.
+        f2.description = "This shouldn't pass"
+        with self.assertRaises(AssertionError) as exc:
+            f2.save()
+
+        self.assertIn(
+            "contractual_issue_date is a required field", exc.exception.args[0]
+        )
+
+        # Assigning contractual_issue_date should allow saving the record.
+        f2.contractual_issue_date = "2025-01-01"
+        f2.description = "This should pass"
+        f2.save()
+
+        self.assertEqual(self.task.contractual_issue_date, Date.to_date("2025-01-01"))

--- a/commown_contractual_issue/views/project_task.xml
+++ b/commown_contractual_issue/views/project_task.xml
@@ -34,7 +34,10 @@
           <group>
             <group>
               <field name="contractual_issue_type" />
-              <field name="contractual_issue_date" />
+              <field
+                                name="contractual_issue_date"
+                                attrs="{'required': [('contractual_issues_tracking', '=', True)]}"
+                            />
             </group>
             <group>
               <field name="penalty_exemption" />


### PR DESCRIPTION
Based on https://github.com/commown/commown-odoo-addons/pull/493