### PR TITLE
[16.0][IMP] project_rating_nps : Change computation of fields based on rating_data methods

### DIFF
--- a/project_rating_nps/models/project.py
+++ b/project_rating_nps/models/project.py
@@ -31,17 +31,13 @@ class Project(models.Model):
                     ),
                 ),
             ]
-            total_count = self.env["rating.rating"].search_count(base_domain)
-            record.rating_count = total_count
-            if total_count == 0:
+            ratings = self.env["rating.rating"].search(base_domain)
+            record.rating_count = total_count = len(ratings)
+            if not ratings:
                 record.net_promoter_score = False
             else:
-                promoters_count = self.env["rating.rating"].search_count(
-                    base_domain + [("rating", ">=", 9)]
-                )
-                detractors_count = self.env["rating.rating"].search_count(
-                    base_domain + [("rating", "<=", 6)]
-                )
+                promoters_count = len(ratings.filtered_domain([("rating", ">=", 9)]))
+                detractors_count = len(ratings.filtered_domain([("rating", "<=", 6)]))
                 record.net_promoter_score = int(
                     100 * (1.0 * promoters_count - detractors_count) / total_count
                 )

--- a/project_rating_nps/models/project.py
+++ b/project_rating_nps/models/project.py
@@ -46,3 +46,36 @@ class Project(models.Model):
                 record.net_promoter_score = int(
                     100 * (1.0 * promoters_count - detractors_count) / total_count
                 )
+
+    def _compute_rating_percentage_satisfaction(self):
+        """
+        This is an overload of the method written in rating/models/rating_parent_mixin.py.
+        Since it uses a function with an assert instruction restricting rating scores
+        between 0 and 5, which doesn't fit our NPS rating (ranging from 0 to 10),
+        this leads to a AssertionError exception when computing affected fields.
+
+        The rating_count value is used in the project.project kanban view, so we assign it.
+        We don't use the other fields, so we assign dummy values to them.
+        """
+        for record in self:
+            domain = [
+                ("parent_res_model", "=", record._name),
+                ("parent_res_id", "=", record.id),
+                ("consumed", "=", True),
+            ]
+            if self._rating_satisfaction_days:
+                dt = fields.datetime.now() - timedelta(
+                    days=record._rating_satisfaction_days
+                )
+                domain += [("write_date", ">=", fields.Datetime.to_string(dt))]
+
+            record.rating_count = self.env["rating.rating"].search_count(domain)
+
+            # Assigning dummy values to unused fields
+            record.write(
+                {
+                    "rating_percentage_satisfaction": -1,
+                    "rating_avg": -1,
+                    "rating_avg_percentage": -1,
+                }
+            )

--- a/project_rating_nps/models/project.py
+++ b/project_rating_nps/models/project.py
@@ -13,6 +13,9 @@ class Project(models.Model):
         compute="_compute_net_promoter_score", string="NPS", store=True, default=False
     )
 
+    # Originally computed in _compute_rating_satisfaction_percentage,
+    rating_count = fields.Integer(compute="_compute_net_promoter_score")
+
     @api.depends("task_ids.rating_ids.rating")
     def _compute_net_promoter_score(self):
         for record in self:
@@ -34,6 +37,7 @@ class Project(models.Model):
                 ),
             ]
             total_count = self.env["rating.rating"].search_count(base_domain)
+            record.rating_count = total_count
             if total_count == 0:
                 record.net_promoter_score = False
             else:
@@ -54,28 +58,12 @@ class Project(models.Model):
         between 0 and 5, which doesn't fit our NPS rating (ranging from 0 to 10),
         this leads to a AssertionError exception when computing affected fields.
 
-        The rating_count value is used in the project.project kanban view, so we assign it.
-        We don't use the other fields, so we assign dummy values to them.
+        We don't use these fields, so we assign dummy values to them.
         """
-        for record in self:
-            domain = [
-                ("parent_res_model", "=", record._name),
-                ("parent_res_id", "=", record.id),
-                ("consumed", "=", True),
-            ]
-            if self._rating_satisfaction_days:
-                dt = fields.datetime.now() - timedelta(
-                    days=record._rating_satisfaction_days
-                )
-                domain += [("write_date", ">=", fields.Datetime.to_string(dt))]
-
-            record.rating_count = self.env["rating.rating"].search_count(domain)
-
-            # Assigning dummy values to unused fields
-            record.write(
-                {
-                    "rating_percentage_satisfaction": -1,
-                    "rating_avg": -1,
-                    "rating_avg_percentage": -1,
-                }
-            )
+        self.write(
+            {
+                "rating_percentage_satisfaction": -1,
+                "rating_avg": -1,
+                "rating_avg_percentage": -1,
+            }
+        )

--- a/project_rating_nps/models/project.py
+++ b/project_rating_nps/models/project.py
@@ -23,13 +23,7 @@ class Project(models.Model):
                 ("parent_res_model", "=", record._name),
                 ("parent_res_id", "=", record.id),
                 ("consumed", "=", True),
-                (
-                    "create_date",
-                    ">=",
-                    fields.Datetime.to_string(
-                        fields.datetime.now() - timedelta(days=30)
-                    ),
-                ),
+                ("create_date", ">=", fields.datetime.now() - timedelta(days=30)),
             ]
             ratings = self.env["rating.rating"].search(base_domain)
             record.rating_count = total_count = len(ratings)

--- a/project_rating_nps/models/project.py
+++ b/project_rating_nps/models/project.py
@@ -23,7 +23,7 @@ class Project(models.Model):
                 ("parent_res_model", "=", record._name),
                 ("parent_res_id", "=", record.id),
                 ("consumed", "=", True),
-                ("create_date", ">=", fields.datetime.now() - timedelta(days=30)),
+                ("write_date", ">=", fields.datetime.now() - timedelta(days=30)),
             ]
             ratings = self.env["rating.rating"].search(base_domain)
             record.rating_count = total_count = len(ratings)

--- a/project_rating_nps/models/project.py
+++ b/project_rating_nps/models/project.py
@@ -16,17 +16,12 @@ class Project(models.Model):
     # Originally computed in _compute_rating_satisfaction_percentage,
     rating_count = fields.Integer(compute="_compute_net_promoter_score")
 
-    @api.depends("task_ids.rating_ids.rating")
+    @api.depends("rating_ids.rating")
     def _compute_net_promoter_score(self):
         for record in self:
-            task_ids = self.env["project.task"].search(
-                [
-                    ("project_id", "=", record.id),
-                ]
-            )
             base_domain = [
-                ("res_model", "=", task_ids._name),
-                ("res_id", "in", task_ids.ids),
+                ("parent_res_model", "=", record._name),
+                ("parent_res_id", "=", record.id),
                 ("consumed", "=", True),
                 (
                     "create_date",

--- a/project_rating_nps/tests/dummy_models.py
+++ b/project_rating_nps/tests/dummy_models.py
@@ -1,0 +1,16 @@
+from odoo import fields, models
+
+
+class NPS_DummyParentModel(models.Model):
+    _name = "project_rating_nps.dummy.parent.model"
+    _inherit = "rating.parent.mixin"
+
+
+class NPS_DummyModel(models.Model):
+    _name = "project_rating_nps.dummy.model"
+    _inherit = "rating.mixin"
+
+    parent_id = fields.Many2one("project_rating_nps.dummy.parent.model")
+
+    def _rating_get_parent_field_name(self):
+        return "parent_id"

--- a/project_rating_nps/tests/test_project.py
+++ b/project_rating_nps/tests/test_project.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Commown SCIC (https://commown.coop)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_test_helper import FakeModelLoader
 
 from odoo.tests.common import TransactionCase
 
@@ -34,3 +35,80 @@ class TestProject(TransactionCase):
             )
             rating.write({"rating": num, "consumed": True})
         self.assertEqual(self.project.net_promoter_score, int(100 * ((2 - 7) / 11.0)))
+
+
+class TestParentRatingComputeOverload(TransactionCase):
+    """
+    This test class aims to test the behavior of the _compute_rating_satisfaction_percentage,
+    which computes several rating fields but using functions containing an assert instruction,
+    which bounds rating scores to be within 0 to 5 (see `odoo/addons/rating/models/rating_data.py`),
+    whereas the NPS system should range from 0 to 10.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+
+        from .dummy_models import NPS_DummyModel, NPS_DummyParentModel
+
+        cls.loader.update_registry((NPS_DummyParentModel, NPS_DummyModel))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        return super().tearDownClass()
+
+    def test_project_model_ok(self):
+        """
+        Project model computation shouldn't crash with fields computed with
+        _compute_rating_satisfaction_percentage method.
+        """
+        # Setup
+        project = self.env["project.project"].create(
+            {"name": "Test project", "rating_status": "stage"}
+        )
+        task = self.env["project.task"].create(
+            {"name": "Test issue", "project_id": project.id}
+        )
+
+        # Without any consumed ratings, the project rating count should be 0
+        self.assertEqual(project.rating_count, 0)
+
+        # Checking if accessing unused computed values doesn't trigger an exception
+        _ = project.rating_percentage_satisfaction
+        _ = project.rating_avg
+        _ = project.rating_avg_percentage
+
+        # A rate of 8 (outside of 0-5 range but within 0-10 range)
+        # shouldn't disrupt rating_count computation.
+        token = task._rating_get_access_token()
+        rating = self.env["rating.rating"].search([("access_token", "=", token)])
+
+        rating.write({"rating": 8, "consumed": True})
+        self.assertEqual(project.rating_count, 1)
+
+    def test_non_project_model_nok(self):
+        """
+        Models other than project.project shouldn't be affected
+        by _compute_rating_satisfaction_percentage overload.
+        (ie. raise an Exception due to the assert instruction)
+        """
+        # Setup
+        parent_dummy = self.env["project_rating_nps.dummy.parent.model"].create({})
+        dummy = self.env["project_rating_nps.dummy.model"].create(
+            {"parent_id": parent_dummy.id}
+        )
+
+        token = dummy._rating_get_access_token()
+        rating = self.env["rating.rating"].search([("access_token", "=", token)])
+
+        # Out-of-range rating value should trigger assert instruction
+        rating.write({"rating": 8, "consumed": True})
+        with self.assertRaises(AssertionError):
+            _ = parent_dummy.rating_count
+
+        # In-range value should allow regular computation
+        rating.write({"rating": 3})
+        self.assertEqual(parent_dummy.rating_count, 1)


### PR DESCRIPTION
- In the `rating/models/rating_data.py` file are functions which allow the `rating` model to obtain several values based on a rating score.
  However, these functions use an `assert` instruction which bound rating scores between 0 to 5, which doesn't fit our NPS system using scores ranging from 0 to 10.
  As such, we overload their compute method to either assign the value found by our NPS method, or a dummy value for unused fields.

- We can use this opportunity to render the NPS into a `rating.parent.mixin` field, since we use the rating count to compute the NPS