### PR TITLE
[16.0][FIX] commown_devices : Removed group element from move line validation wizard

### DIFF
--- a/commown_devices/views/wizard_move_line_validation.xml
+++ b/commown_devices/views/wizard_move_line_validation.xml
@@ -5,10 +5,8 @@
     <field name="arch" type="xml">
       <form string="Confirm validation">
         <sheet>
-          <group>
-            <field name="move_line_id" invisible="1" />
-            <field name="message" nolabel="1" readonly="1" />
-          </group>
+          <field name="move_line_id" invisible="1" />
+          <field name="message" nolabel="1" readonly="1" />
         </sheet>
         <footer>
           <button


### PR DESCRIPTION
# Current visual
<img width="1256" height="443" alt="Move line confirmation wizard, with message field text cramped to the right of the modal window" src="https://github.com/user-attachments/assets/d0ad3888-4aeb-4221-9fdc-a3d9e24ad9f9" />


# After `group` element removal
<img width="1304" height="257" alt="Move line confirmation wizard, with message field text all across the modal window" src="https://github.com/user-attachments/assets/c9d123be-6031-4a31-b5fe-c3ab88791a98" />
