### PR TITLE
[16.0][FIX] product_rental : Fixed XPath element attribute modification

### DIFF
--- a/product_rental/views/website_sale_templates.xml
+++ b/product_rental/views/website_sale_templates.xml
@@ -99,8 +99,10 @@
     <!-- Hide spans containing the extra prices in both select and radio inputs -->
     <xpath
             expr="//*[hasclass('sign_badge_price_extra')]//ancestor::span"
-            t-if="False"
-        />
+            position="attributes"
+        >
+      <attribute name="t-if">False</attribute>
+    </xpath>
 
   </template>
 


### PR DESCRIPTION
# Current state
<img width="590" height="124" alt="Select field for 'Stockage / RAM' attribute, currently set to '256Go / 8Go + 8,91€'" src="https://github.com/user-attachments/assets/d40c8bbe-1e45-468c-b493-37f3d9f3ba2d" />


# After XPath rearrangement
<img width="608" height="119" alt="Select field for 'Stockage / RAM' attribute, currently set to '256Go / 8Go'" src="https://github.com/user-attachments/assets/000abad0-ba4f-4ce6-ba06-8b803e70f7ed" />

___
### Notes 

While we hide the `span` element displaying the `price_extra` field, we could also use it to display instead the `recurrent_payment_amount_extra` which would display the additionnal cost of any given attribute.
However, the current fix re-establishes the visual of the v12 instance (without the extra amount of any given attribute)