### PR TITLE
[16.0][IMP] account_invoice_merge_auto_pay: Added default False value to auto_merge for newly created reserve moves

### DIFF
--- a/account_invoice_merge_auto_pay/models/__init__.py
+++ b/account_invoice_merge_auto_pay/models/__init__.py
@@ -1,1 +1,2 @@
+from . import account_move_reversal
 from . import account_move

--- a/account_invoice_merge_auto_pay/models/account_move_reversal.py
+++ b/account_invoice_merge_auto_pay/models/account_move_reversal.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class AccountMoveReversal(models.TransientModel):
+    _inherit = "account.move.reversal"
+
+    def _prepare_default_reversal(self, move):
+        res = super()._prepare_default_reversal(move)
+        res.update({"auto_merge": False})
+        return res

--- a/account_invoice_merge_auto_pay/tests/test_account_move.py
+++ b/account_invoice_merge_auto_pay/tests/test_account_move.py
@@ -112,3 +112,27 @@ class AccountMoveTC(AccountMoveMergeAutoPayMixin):
             self._merge_and_pay()
 
         self.assertIn("No payment token", err.exception.args[0])
+
+    def test_reversed_move_no_auto_merge(self):
+        "Reversed moves created using the account.move.reversal wizard should have the auto_merge value to False"
+        inv = self.create_invoice(self.partner_a, "2019-05-10", 1.0)
+        inv.action_post()
+
+        self.assertTrue(inv.auto_merge)  # Test pre-requisite
+
+        # Creating reserval move, and checking its auto_merge field
+        wiz = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=inv.ids)
+            .create(
+                {
+                    "move_ids": inv.ids,
+                    "journal_id": inv.journal_id.id,
+                    "refund_method": "refund",
+                }
+            )
+        )
+        wiz.reverse_moves()
+
+        reversed_inv = inv.reversal_move_id
+        self.assertFalse(reversed_inv.auto_merge)


### PR DESCRIPTION
To create a reversed move of a given move, the `reverse_moves` method copies the original move, to get the same fields, except for values set in the default_values_list argument.

However, in the `_reverse_moves` method overload of the `account_payment_partner`, a `payment_mode_id` is set, to try to fetch a refund payment mode (`move.payment_mode_id.refund_payment_mode_id`), which can be False.

This causes an issue when the record is created, since if the `auto_merge` value of the original move is set to True, and the `payment_mode_id` value is False, the `_check_auto_merge` method raises an error.

As such, for newly created reverse moves, we set the `auto_merge` value to False.