### PR TITLE
[16.0][IMP] commown: Moved the sale warning message right to another place

### DIFF
--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -183,7 +183,7 @@
   <template id="product" inherit_id="website_sale_b2b.product_b2b">
 
     <!-- Display availability warning for service products -->
-    <xpath expr="//a[@id='add_to_cart']" position="after">
+    <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
       <t
                 t-set="availability_class"
                 t-value="product.type == 'service' and {'warning': 'warning', 'block': 'danger'}.get(product.sale_line_warn, '') or ''"


### PR DESCRIPTION
The website_sale_cart_selectable module affects the website_sale.product template, by replacing the o_wsale_cta_wrapper div when the product's website_btn_addtocart_published value is set to True.

As such, after adding the sale warn message right after the add_to_button element, contained within the o_wsale_cta_wrapper div, it gets removed from the DOM if that div is replaced.

As such, we instead insert the message right after the o_wsale_cta_wrapper div element, to insure its visibility even after the o_wsale_cta_wrapper element is replaced.
___
# With the Add to cart button enabled
<img width="966" height="250" alt="A button labelled 'Add to cart' and a warning text block, saying 'Message d'avertissement de test' placed under, on a store page" src="https://github.com/user-attachments/assets/005b9c77-252e-4a38-b73d-f48e4093690a" />


# With the Add to cart button disabled
<img width="966" height="152" alt="Warning text block, saying 'Message d'avertissement de test' on a store page" src="https://github.com/user-attachments/assets/4bf95428-e491-462c-8796-2e0b74a02879" />
