### PR TITLE
Fix wrong stage for new sale followup tasks

### DIFF
--- a/commown_lead_risk_analysis/models/sale_order.py
+++ b/commown_lead_risk_analysis/models/sale_order.py
@@ -21,11 +21,11 @@ class SaleOrder(models.Model):
             record._create_followup_entities()
         return result
 
-    def choose_stage(self, team):
-        stages = self.env["crm.stage"].search(
-            [("team_id", "=", team.id)], order="sequence"
+    def choose_stage(self, model_name, parent_entity, relation_name):
+        stages = self.env[model_name].search(
+            [(relation_name, "=", parent_entity.id)], order="sequence"
         )
-        stage = stages[0] if stages else self.env["crm.stage"]
+        stage = stages[0] if stages else False
         for _stage in stages:
             if "[stage: start]" in _stage.name:
                 stage = _stage
@@ -36,13 +36,14 @@ class SaleOrder(models.Model):
         return self.env["contract.contract"].of_sale(self)
 
     def _create_followup_entity_crm_lead(self, prefix, team, so_line, contract=None):
+        stage = self.choose_stage("crm.stage", team, "team_id")
         lead = self.env["crm.lead"].create(
             {
                 "name": " ".join([prefix, so_line.product_id.display_name]),
                 "partner_id": self.partner_id.id,
                 "type": "opportunity",
                 "team_id": team.id,
-                "stage_id": self.choose_stage(team).id,
+                "stage_id": stage and stage.id,
                 "so_line_id": so_line.id,
                 "contract_id": contract.id if contract else False,
             }
@@ -63,12 +64,13 @@ class SaleOrder(models.Model):
                 "contract": contract,
             }
         )
+        stage = self.choose_stage("project.task.type", project, "project_ids")
         return self.env["project.task"].create(
             {
                 "name": " ".join([prefix, so_line.product_id.name]),
                 "partner_id": self.partner_id.id,
                 "project_id": project.id,
-                "stage_id": self.choose_stage(project).id,
+                "stage_id": stage and stage.id,
                 "contract_id": contract.id if contract else False,
                 "description": description,
             }

--- a/commown_lead_risk_analysis/tests/test_sale_order.py
+++ b/commown_lead_risk_analysis/tests/test_sale_order.py
@@ -138,9 +138,15 @@ class SaleOrderTC(RentalSaleOrderTC):
         self.assertEqual(len(leads2), 1)
         self.assertEqual(len(leads3), 2)
 
-    def test_create_project_tasks_with_contracts(self):
+    def new_project_stage(self, project, name):
+        stage = self.env["project.task.type"].create({"name": name})
+        stage.project_ids |= project
+        return stage
 
+    def test_create_project_tasks_with_contracts(self):
         my_project = self.env["project.project"].create({"name": "my project"})
+        self.new_project_stage(my_project, "stage 1")
+        start_stage = self.new_project_stage(my_project, "stage 2 [stage: start]")
         self.product1.followup_sales_project_id = my_project
         self.product1.property_contract_template_id.stock_ownership = "customer"
 
@@ -157,6 +163,7 @@ class SaleOrderTC(RentalSaleOrderTC):
 
         so.action_confirm()
         self.assertEqual(len(my_project.task_ids), 2)
+        self.assertEqual(my_project.task_ids.mapped("stage_id"), start_stage)
         self.assertEqual(
             my_project.mapped("task_ids.contract_id.stock_ownership"),
             ["customer", "customer"],


### PR DESCRIPTION
The followup tasks created when the sale of a contract product with a 'followup_sales_project_id' non-empy field is confirmed, was created with an undefined stage_id. The method to choose this stage was not adapted to the project.task stage case but only to the crm.lead case.

This is now fixed, and a test was added.