### PR TITLE
[16.0][IMP] website_sale_b2b: Changed the default add_qty value to be an integer

### DIFF
--- a/website_sale_b2b/controllers/main.py
+++ b/website_sale_b2b/controllers/main.py
@@ -102,7 +102,7 @@ class WebsiteSaleB2B(WebsiteSale):
         result = super().product(product, category, search, **kwargs)
         result.qcontext["rental_infos"] = rental_infos
         if forced_add_qty:
-            result.qcontext["add_qty"] = forced_add_qty
+            result.qcontext["add_qty"] = int(forced_add_qty)
         return result
 
     def checkout_form_validate(self, mode, all_form_values, data):


### PR DESCRIPTION
Since we sell devices and accessories, it's not possible to order half of a device (three-and-a-half Fairphones, for instance). However, on the product page, it's possible to set a floating value, and the default value is a float, meaning the first decimal is shown (ie. "10.0")

While the quantity gets rounded to an integer when added to the cart, it can still mislead users on the store. As such, we force the default add_qty value to an integer when passing the default add_qty value to the product template.