### PR TITLE
[16.0][FIX] commown_self_troubleshooting: Added explicit non-user assignment of newly created self-troubleshoot tasks

### DIFF
--- a/commown_self_troubleshooting/controllers/main.py
+++ b/commown_self_troubleshooting/controllers/main.py
@@ -61,6 +61,7 @@ class SelfHelp(http.Controller):
             "contractual_issue_type": post.get("contractual_issue_type"),
             "contractual_issue_date": post.get("contractual_issue_date"),
             "partner_id": partner.id,
+            "user_ids": False,
             "description": self._description(**post),
             "project_id": project.id,
             "tag_ids": [(6, 0, self._tag_ids(**post))],


### PR DESCRIPTION
In Odoo v12, when creating a project.task through the create_method, the default values of the model (default_get) didn't add assign a value to user_id.

However, in Odoo v16, the same method now assigns the current environnement user as the default assignee to the newly created task, who can be a customer when a task is created through the self-troubleshoot.

As such, we explicitly set the user_ids value to False, to avoid having the customer be assigned to the task.