### PR TITLE
[16.0][IMP] customer_team_manager: Changed domain on partner parent field to a direct comparaison

### DIFF
--- a/customer_team_manager/security/rules.xml
+++ b/customer_team_manager/security/rules.xml
@@ -43,7 +43,7 @@
         />
     <field
             name="domain_force"
-        >[('id', 'child_of', user.commercial_partner_id.id), ('is_company', '=', False)]</field>
+        >[('parent_id', '=', user.commercial_partner_id.id), ('is_company', '=', False)]</field>
     <field name="perm_read" eval="True" />
     <field name="perm_write" eval="True" />
     <field name="perm_create" eval="True" />


### PR DESCRIPTION
Using the child_of operator prevented Customer Admins from seeing archived partners :

  After establishing a rule on a record, Odoo checks if a user has access to a record through check_access_rule,
  which checks the domains applying on a domain and checking if there are any outliners.

  However, when using the child_of (or parent_of) operators, a search operation is performed to check the records' parents or children.
  This is problematic when searching inactive records, since the search method excludes inactive records by default.
  This leads to a UserError raise from the customer admin view, if a customer admin tries to access an inactive partner, or filter through
  their inactive users.

=> As such, we change the child_of operator by a direct comparaison on the parent field, which is processed through a direct Python comparaison
   rather than a search operation.