### PR TITLE
[16.0][IMP] commown: Added codeview option on the product.template website_description HTML field

### DIFF
--- a/commown/views/product_template.xml
+++ b/commown/views/product_template.xml
@@ -19,6 +19,7 @@
           <field
                         name="website_description"
                         attrs="{'readonly': [('is_user_lang_fr', '=', False)]}"
+                        options="{'codeview': true}"
                     />
         </group>
       </xpath>


### PR DESCRIPTION
  In Odoo v12, web_editor adds an extended HTML editor based on the Summernote library, and always called its codeview option systematically for HTML fields.

  However, in Odoo v16, the extended editor was revamped within Odoo, and while the codeview option, to check the HTML structure directly, is still present, it's now activated optionally.

  Since we used the HTML codeview on the website_description fields in our operations (for instance, to assign CSS classes 'fr' or 'de' on links to only show the links in the customer's language), we add this option to once again be able to edit the HTML structure of this field directly.