### PR TITLE
[16.0][FIX] commown_support/commown_administrative_docs: Migrated SMS mail.template to sms.templates

### DIFF
--- a/commown_administrative_docs/data/mail_template.xml
+++ b/commown_administrative_docs/data/mail_template.xml
@@ -1,20 +1,12 @@
 <odoo>
 
-  <record id="sms_template_lead_doc_reminder" model="mail.template">
+  <record id="sms_template_lead_doc_reminder" model="sms.template">
     <field name="name">[commown] SMS relance doc</field>
-    <field
-            name="subject"
-        ><![CDATA[mail2smsid=xxx&sendername=Commown&recipients=<t t-out="''.join((object.partner_id.mobile or object.partner_id.phone).split()).replace('+', '')" />]]></field>
-    <field name="email_from">contact@commown.coop</field>
-    <field name="email_to">mail2sms@envoyersmspro.com</field>
     <field name="model_id" ref="crm.model_crm_lead" />
     <field name="lang">False</field>
-    <field name="auto_delete">True</field>
     <field
-            name="body_html"
-        ><![CDATA[
-Rappel finalisation de votre commande : Pensez à mettre vos documents en ligne svp !
-]]></field>
+            name="body"
+        >Rappel finalisation de votre commande : Pensez à mettre vos documents en ligne svp !</field>
   </record>
 
 </odoo>

--- a/commown_support/data/mail_templates.xml
+++ b/commown_support/data/mail_templates.xml
@@ -39,21 +39,13 @@
 ]]></field>
   </record>
 
-  <record id="sms_template_issue_reminder" model="mail.template">
+  <record id="sms_template_issue_reminder" model="sms.template">
     <field name="name">[commown] SAV : relance SMS</field>
-    <field
-            name="subject"
-        ><![CDATA[mail2smsid=xxx&sendername=Commown&recipients=<t t-out="''.join((object.partner_id.mobile or object.partner_id.phone).split()).replace('+', '')" />]]></field>
-    <field name="email_from">contact@commown.coop</field>
-    <field name="email_to">mail2sms@envoyersmspro.com</field>
     <field name="model_id" ref="project.model_project_task" />
     <field name="lang">False</field>
-    <field name="auto_delete">True</field>
     <field
-            name="body_html"
-        ><![CDATA[
-<p>Bonjour, suite à votre demande d'assistance nos courriels sont restés sans réponse. Vérifiez vos spams pour y répondre ou ignorez ce SMS pour la clore.</p>
-]]></field>
+            name="body"
+        >Bonjour, suite à votre demande d'assistance nos courriels sont restés sans réponse. Vérifiez vos spams pour y répondre ou ignorez ce SMS pour la clore.</field>
   </record>
 
 </odoo>


### PR DESCRIPTION
The send_sms_from_template method was updated to take a sms.template as template, rather than a mail.template record. However, the used templates in commown_support/commown_administrative_docs were not accordingly migrated to a sms.template.

As such, we update them here.