### PR TITLE
[16.0][IMP] commown: Hide "Alle Produkte' category from shop

### DIFF
--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -168,15 +168,9 @@
 
   <!-- Language related hacks START -->
 
-  <template
-        id="products_categories_list"
-        inherit_id="website_sale.products_categories_list"
-    >
-    <xpath
-            expr="//t[@t-call='website_sale.categories_recursive']"
-            position="attributes"
-        >
-      <attribute name="t-if">c != env.ref('commown.categ_de')</attribute>
+  <template id="products" inherit_id="website_sale.products">
+    <xpath expr="//div[hasclass('o_wsale_products_page')]" position="before">
+      <t t-set="categories" t-value="categories - env.ref('commown.categ_de')" />
     </xpath>
   </template>
 

--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -174,6 +174,13 @@
     </xpath>
   </template>
 
+  <template id="products_only_search" inherit_id="website_sale.search">
+    <!-- Override search_type value to include products only, and not categories -->
+    <xpath expr="//t[@t-set='search_type']" position="attributes">
+      <attribute name="t-valuef">products_only</attribute>
+    </xpath>
+  </template>
+
   <template id="product" inherit_id="website_sale_b2b.product_b2b">
 
     <!-- Display availability warning for service products -->

--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -179,6 +179,12 @@
     <xpath expr="//t[@t-set='search_type']" position="attributes">
       <attribute name="t-valuef">products_only</attribute>
     </xpath>
+
+    <!-- Hide extra links (used to display product's public categories) -->
+    <xpath expr="//t[@t-set='display_extra_link']" position="attributes">
+      <attribute name="t-valuef">false</attribute>
+    </xpath>
+
   </template>
 
   <template id="product" inherit_id="website_sale_b2b.product_b2b">


### PR DESCRIPTION
This hides the Alle Produkte category from :
- the sidebar/topbar category options
<img width="1148" height="520" alt="Screenshot of an online shop with several products arranged in a grid. On the side is a list of categories, as well as on the top. Both contain the 'Smartphone', 'Ordinateur', 'Audio', 'Investir' and 'Téléphone mobile' categories." src="https://github.com/user-attachments/assets/937bddfd-42fd-413e-97f7-54b7136ce690" />


- the autocomplete search
<img width="774" height="317" alt="Screenshot of an online shop search bar, with 'Alle' as the imput. Beneath is an autocomplete list with listed one product named 'Installer un Android sans Google (/e/OS) ou revenir l'Android avec Google'." src="https://github.com/user-attachments/assets/c8661b91-0d55-4b0e-aed1-3a8d37ec0921" />

