### PR TITLE
[16.0][FIX] contract_payment_auto_job_post_process: Added test_target_state…

### DIFF
--- a/contract_payment_auto_job_post_process/tests/base.py
+++ b/contract_payment_auto_job_post_process/tests/base.py
@@ -1,0 +1,9 @@
+from odoo import models
+
+
+class TestTargetStateContextBase(models.AbstractModel):
+    _inherit = "base"
+
+    def _job_prepare_context_before_enqueue_keys(self):
+        res = super()._job_prepare_context_before_enqueue_keys()
+        return res + ("test_target_state",)

--- a/contract_payment_auto_job_post_process/tests/test_contract.py
+++ b/contract_payment_auto_job_post_process/tests/test_contract.py
@@ -17,7 +17,9 @@ class TestContract(TestContractBase):
         cls.loader.backup_registry()
         from odoo.addons.contract_payment_auto.tests.models import TransactionTest
 
-        cls.loader.update_registry((TransactionTest,))
+        from .base import TestTargetStateContextBase
+
+        cls.loader.update_registry((TransactionTest, TestTargetStateContextBase))
 
         # Configure invoice creation in jobs and contract automatic payment:
         cls.env["ir.config_parameter"].sudo().set_param("contract.queue.job", "True")


### PR DESCRIPTION
… to list of allowed context keys

In the following PR, the v16.0 queue_job module was patched to filter context keys, to only allow a select amount of context keys. -> https://github.com/OCA/queue/pull/794

Due to this module's purpose, using both contract_payment_auto (passing test_target_state in tx tests) and contract_queue_job (performing invoice creation in jobs), we might need to create a new module in OCA/contract in order to offer the possibility to other users to pass the test_target_state context value in tests, while using a job to perform invoice creation.
However, in the meantime, we added this fix in this module.