### PR TITLE
[16.0][IMP] product_rental: Improve prices display

### DIFF
--- a/product_rental/static/src/css/website_sale.css
+++ b/product_rental/static/src/css/website_sale.css
@@ -1,4 +1,4 @@
-div.is_deposit h4.oe_price_h4 {
+div.is_deposit h3.oe_price_h3 {
     /* Deposit price is less important than rental price decrease it */
     font-size: inherit;
 }

--- a/product_rental/views/website_sale_templates.xml
+++ b/product_rental/views/website_sale_templates.xml
@@ -73,11 +73,6 @@
                 id="product_recurrent_payment_amount"
                 class="product_price mt16"
             >
-        <p t-if="product.is_contract and commitment_period['number'] > 0">
-          <b class="commitment"><span>Commitment duration: </span><span
-                            t-esc="commitment_period['number']"
-                        /> <span t-esc="commitment_period['type']" /></b>
-        </p>
         <h4 class="oe_price_h4 css_editable_mode_hidden">
           <b
                         class="oe_recurrent_payment_amount"
@@ -88,6 +83,11 @@
                     />
           <b t-field="product.recurrent_payment_frequency" />
         </h4>
+        <p t-if="product.is_contract and commitment_period['number'] > 0">
+          <b class="commitment"><span>Commitment duration: </span><span
+                            t-esc="commitment_period['number']"
+                        /> <span t-esc="commitment_period['type']" /></b>
+        </p>
       </div>
     </xpath>
 

--- a/product_rental/views/website_sale_templates.xml
+++ b/product_rental/views/website_sale_templates.xml
@@ -73,7 +73,7 @@
                 id="product_recurrent_payment_amount"
                 class="product_price mt16"
             >
-        <h4 class="oe_price_h4 css_editable_mode_hidden">
+        <h3 class="oe_price_h3 css_editable_mode_hidden">
           <b
                         class="oe_recurrent_payment_amount"
                         style="white-space: nowrap;"
@@ -82,7 +82,7 @@
                         t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                     />
           <b t-field="product.recurrent_payment_frequency" />
-        </h4>
+        </h3>
         <p t-if="product.is_contract and commitment_period['number'] > 0">
           <b class="commitment"><span>Commitment duration: </span><span
                             t-esc="commitment_period['number']"


### PR DESCRIPTION
# Current visual
<img width="1302" height="468" alt="Store page for a product 'Fairphone 4'. On the right side of the image is displayed a picture of the Fairphone 4. On the left side is displayed contractual information, as well as payment/commitment information, displayed in the following order : Deposit amount, commitment duration, recurrent payment amount" src="https://github.com/user-attachments/assets/f625c2b0-a284-4823-99b7-68a5f3f37bdf" />

# New visual
<img width="1302" height="468" alt="Store page for a product 'Fairphone 4'. On the right side of the image is displayed a picture of the Fairphone 4. On the left side is displayed contractual information, as well as payment/commitment information, displayed in the following order : Deposit amount, recurrent payment amount, commitment duration" src="https://github.com/user-attachments/assets/99ae9db9-6987-4ca3-8ffd-a69675caebe7" />