### PR TITLE
[12.0][IMP] customer_team_manager: Changed domain on partner parent field to a direct comparaison

### DIFF
--- a/customer_team_manager/security/rules.xml
+++ b/customer_team_manager/security/rules.xml
@@ -26,7 +26,7 @@
     <field name="name">Customer Team Manager: read/ create/ write only same Company partners</field>
     <field name="model_id" ref="model_res_partner"/>
     <field name="groups" eval="[(4, ref('customer_team_manager.group_customer_admin'))]"/>
-    <field name="domain_force">[('id', 'child_of', user.commercial_partner_id.id), ('is_company', '=', False)]</field>
+    <field name="domain_force">[('parent_id', '=', user.commercial_partner_id.id), ('is_company', '=', False)]</field>
     <field name="perm_read" eval="True"/>
     <field name="perm_write" eval="True"/>
     <field name="perm_create" eval="True"/>


### PR DESCRIPTION
In Odoo v16, using the child_of operator prevented Customer Admins from seeing archived partners. (see https://github.com/commown/commown-odoo-addons/pull/531 for more info)

However, this change between the 2 versions might cause confusion, if differences related to this change are noted. and so we backport this feature.

Since all grandparented-partners were created by Commown employees, sometimes resulting in duplicate partnersin the Team Manager view, it might clear data for end users.
This also avoids some unwanted behavior - for instance, independants enterprises within a CAE won't be able to see each other as simply, and can reserve their partner information to each other.