### PR TITLE
[16.0][FIX] urban_mine: Inserted computed Country ids rather than fixed ids

### DIFF
--- a/urban_mine/data/registration_page.xml
+++ b/urban_mine/data/registration_page.xml
@@ -232,10 +232,10 @@
                                                     required="1"
                                                 >
                           <option style="display:none" />
-                          <option value="12">Austria</option>
-                          <option value="20">Belgium</option>
-                          <option value="75">France</option>
-                          <option value="57">Germany</option>
+                          <option t-att-value="env.ref('base.at').id">Austria</option>
+                          <option t-att-value="env.ref('base.be').id">Belgium</option>
+                          <option t-att-value="env.ref('base.fr').id">France</option>
+                          <option t-att-value="env.ref('base.de').id">Germany</option>
                         </select>
                       </div>
                       <div


### PR DESCRIPTION
In Odoo v16, we constructed this form using the generated form using the website form editor, before taking its HTML structure and inserting it into the module. However, we kept the generated ids for a simple database, and its corresponding country ids in the Country field.

This poses a problem in other database which have gone through several version migrations, and might have other country records, causing a shift in intended ids.
For instance, our database started in Odoo V10, in which a country record was created for Netherlands Antilles, which once ported to v16 shifted the ids of all countries, including the ones intended for this form, by one.

To avoid this type of shenanigans in the future, we instead compute the wanted country ids on-the-fly in the form.