### PR TITLE
[16.0][IMP] commown_b2b_mail_channel: Restored translate attribute on mail.channel name field

### DIFF
--- a/commown_b2b_mail_channel/models/mail_channel.py
+++ b/commown_b2b_mail_channel/models/mail_channel.py
@@ -4,6 +4,8 @@ from odoo import api, fields, models
 class MailChannel(models.Model):
     _inherit = "mail.channel"
 
+    name = fields.Char(translate=True)
+
     partner_companies = fields.One2many(
         "res.partner",
         inverse_name="mail_channel_id",


### PR DESCRIPTION
The name field from the mail.channel model was translatable in Odoo 15.0 and earlier versions. However, in the v16 version of the mail module, the translate attribute was removed. -> https://github.com/odoo/odoo/commit/d46e879983f349765b8fe413965b5976205ffd89

Since we used the translate attribute to display B2B channels names in different languages, we restore the translate attribute on this field, in our module.