### PR TITLE
[16.0][FIX] commown_self_troubleshooting : Fixed customer creating their own task

### DIFF
--- a/commown_self_troubleshooting/controllers/main.py
+++ b/commown_self_troubleshooting/controllers/main.py
@@ -52,6 +52,7 @@ class SelfHelp(http.Controller):
         env = request.env
         partner = env.user.partner_id
         post = request.params.copy()
+        root_user = env.ref("base.user_root")
 
         project = env.ref(post["project_ref"])
 
@@ -76,13 +77,13 @@ class SelfHelp(http.Controller):
             stage_ref = post["stage_ref"]
             task_data["stage_id"] = env.ref(stage_ref).id
 
-        task = env["project.task"].sudo().create(task_data)
+        task = env["project.task"].with_user(root_user).create(task_data)
         task.onchange_contract_or_product()
 
         if partner not in task.message_follower_ids.mapped("partner_id"):
             comment = env.ref("mail.mt_comment")
             rating = env.ref("project.mt_task_rating")
-            env["mail.followers"].create(
+            env["mail.followers"].with_user(root_user).create(
                 {
                     "res_model": task._name,
                     "res_id": task.id,

--- a/commown_self_troubleshooting/tests/test_tour.py
+++ b/commown_self_troubleshooting/tests/test_tour.py
@@ -148,6 +148,24 @@ class TestPageRealContractTC(RunTourTC, DeviceAsAServiceTC):
         contract.date_start = "2023-09-01"
         self._run_tour("commown_self_troubleshooting_tour_theft_and_loss")
 
+        # Checking the partner was notified by the automatic Theft/Loss mail
+        theft_and_loss_project = self.env.ref(
+            "product_rental.contract_theft_and_loss_project"
+        )
+        task = self.env["project.task"].search(
+            [
+                ("contract_id", "=", contract.id),
+                ("partner_id", "=", contract.partner_id.id),
+                ("project_id", "=", theft_and_loss_project.id),
+            ]
+        )
+
+        task_messages = task.message_ids.filtered(
+            lambda m: m.subtype_id.name != "Task Created"
+        )
+        self.assertTrue(task_messages)
+        self.assertIn(contract.partner_id, task_messages.notified_partner_ids)
+
 
 class TestPageGSDay(TestTourWithContractTC):
     contract_name = "GS/B2C"


### PR DESCRIPTION
(Depends on https://github.com/commown/commown-odoo-addons/pull/543 )

This caused a glitch in the Theft/Loss self-troubleshoot form, as the customer was considered as sending their own email, and as such, not receiving the mail.