### PR TITLE
[16.0][IMP] commown: Hid payment method management page link in customer portal

### DIFF
--- a/commown/views/website_portal_templates.xml
+++ b/commown/views/website_portal_templates.xml
@@ -191,4 +191,11 @@
 
   <!-- End Customize portal section titles -->
 
+  <!-- Hide "Manage payment methods" link -->
+  <template id="hide_pay_meth_link" inherit_id="payment.pay_meth_link">
+    <xpath expr="//a[@href='/my/payment_method']" position="attributes">
+      <attribute name="t-if">False</attribute>
+    </xpath>
+  </template>
+
 </odoo>


### PR DESCRIPTION
# Current visual 
<img width="481" height="218" alt="A screenshot of a page with the following lines texts going as follow : 'Carte d'identité' with a check icon, 'Justificatif de domicile' with a check icon, 'Gérer les modes de paiements' highlighted as a link and 'Documentation - Tutoriels' as a bigger title" src="https://github.com/user-attachments/assets/ef811221-b769-4936-8a89-38aac66337e7" />

# New visual
<img width="460" height="167" alt="A screenshot of a page with the following lines texts going as follow : 'Carte d'identité' with a check icon, 'Justificatif de domicile' with a check icon, 'Gérer les modes de paiements' highlighted as a link and 'Documentation - Tutoriels' as a bigger title" src="https://github.com/user-attachments/assets/d7cc5eb4-5353-4c7a-a836-77a2d57b762b" />
