### PR TITLE
[16.0][IMP] product_rental: Display recurring_next_date as readonly when line_recurrence is activated

### DIFF
--- a/product_rental/views/contract.xml
+++ b/product_rental/views/contract.xml
@@ -82,6 +82,24 @@
 	<attribute name="string">Recurrence</attribute>
       </xpath>
 
+      <xpath expr="//field[@name='recurring_next_date']/.." position="attributes">
+        <!--
+          Removing "{'invisible': [('line_recurrence', '=', True)]}"
+          to always display the 'recurring_next_date' field
+        -->
+        <attribute name="attrs" value="{}" />
+      </xpath>
+
+      <xpath expr="//field[@name='recurring_next_date']" position="attributes">
+        <!--
+          Set 'recurring_next_date' as readonly when it would natively be invisible
+          (see above XPath modification)
+        -->
+        <attribute
+                    name="attrs"
+                >{'readonly': [('line_recurrence', '=', True)]}</attribute>
+      </xpath>
+
       <field name="contract_template_id" position="after">
 	<field
                     name="contractual_documents"


### PR DESCRIPTION
# Current visual
<img width="362" height="156" alt="image" src="https://github.com/user-attachments/assets/381b57ff-d8df-48cf-8ba1-9b30c4ec40fb" />

# New visual
<img width="349" height="175" alt="Capture d’écran du 2026-01-08 16-06-31" src="https://github.com/user-attachments/assets/d78a97f2-fbd9-4fc4-b84d-8ecd1f86c819" />
