### PR TITLE
Add connect and read timeouts to colissimo tracking requests

### DIFF
--- a/commown_shipping/models/delivery_mixin.py
+++ b/commown_shipping/models/delivery_mixin.py
@@ -106,9 +106,16 @@ class CommownTrackDeliveryMixin(models.AbstractModel):
 
     @api.multi
     def write(self, values):
+
+        _act = None
+        if "delivery_date" in values:
+            _act = self.filtered(lambda o: o.delivery_date != values["delivery_date"])
+
         res = super(CommownTrackDeliveryMixin, self).write(values)
-        if values.get("delivery_date", False):
-            self.delivery_perform_actions()
+
+        if _act:  # Not None nor empty resultset
+            _act.delivery_perform_actions()
+
         return res
 
     @api.multi
@@ -181,6 +188,10 @@ class CommownTrackDeliveryMixin(models.AbstractModel):
     @job(default_channel=QUEUE_CHANNEL)
     def _delivery_tracking_update(self):
         self.ensure_one()
+
+        if self.delivery_date:
+            return "Parcel already delivered... Skipping."
+
         now = datetime.datetime.utcnow()
 
         infos = self._delivery_tracking_colissimo_status()

--- a/commown_shipping/models/delivery_mixin.py
+++ b/commown_shipping/models/delivery_mixin.py
@@ -16,6 +16,8 @@ QUEUE_CHANNEL = "root.DELIVERY_TRACKING"
 
 MLVARS_MAX_WAIT = datetime.timedelta(days=8)
 
+TIMEOUT = (10, 15)
+
 
 class ParcelError(Exception):
     pass
@@ -23,7 +25,9 @@ class ParcelError(Exception):
 
 def colissimo_status_request(account, password, ref):
     resp = requests.get(
-        BASE_URL, {"accountNumber": account, "password": password, "skybillNumber": ref}
+        BASE_URL,
+        {"accountNumber": account, "password": password, "skybillNumber": ref},
+        timeout=TIMEOUT,
     )
     resp.raise_for_status()
     return resp.content.decode("utf-8")

--- a/commown_shipping/tests/test_crm_lead.py
+++ b/commown_shipping/tests/test_crm_lead.py
@@ -421,6 +421,38 @@ class CrmLeadDeliveryTrackingTC(TransactionCase, CheckMailMixin):
         self.assertEqual(leads.mapped("expedition_status"), ["[LIVCFM] test label"] * 2)
         self.assertEqual(leads.mapped("stage_id"), self.stage_final)
 
+    def test_duplicated_tracking_job(self):
+        "Re-submitted jobs before the first ones were completed must do nothing"
+
+        def _delivered_parcel_emails(lead):
+            return self._object_messages(lead).filtered(
+                lambda m: m.subject == "Product delivered"
+            )
+
+        # Simulate jobs are re-created (trap2) before the others are ended (trap1):
+        with trap_jobs() as trap1:
+            leads1 = self.env["crm.lead"]._cron_delivery_auto_track()
+
+        with trap_jobs() as trap2:
+            leads2 = self.env["crm.lead"]._cron_delivery_auto_track()
+
+        # Check the concerned leads are the same
+        self.assertTrue(len(leads1) > 0 and leads1 == leads2)
+
+        tracking_results = {l: _status("LIVCFM") for l in ("l1", "l2")}
+
+        for job in trap1.enqueued_jobs:
+            lead = job.recordset
+            lead.send_email_on_delivery = True
+            _mock_delivery_job(job, lambda *args: tracking_results[lead.name])
+            self.assertEqual(len(_delivered_parcel_emails(lead)), 1)
+
+        # Execute duplicated jobs and check their result: job skipped, email not sent
+        for job in trap2.enqueued_jobs:
+            job.perform()  # No need to mock here as we return before calling colissimo
+            self.assertIn("Skipping", job.result)
+            self.assertEqual(len(_delivered_parcel_emails(lead)), 1)
+
     def test_cron_ok2(self):
         lead1, lead2 = self.exec_job_with_status(
             {"l1": _status("LIVCFM"), "l2": _status("RENLNA")}

--- a/commown_shipping/tests/test_crm_lead.py
+++ b/commown_shipping/tests/test_crm_lead.py
@@ -14,6 +14,15 @@ from ..models.delivery_mixin import CommownTrackDeliveryMixin as DeliveryMixin
 from .common import BaseShippingTC, pdf_page_num
 
 
+def _mock_delivery_job(job, result):
+    with patch.object(
+        DeliveryMixin,
+        "_delivery_tracking_colissimo_status",
+        side_effect=result,
+    ):
+        job.perform()
+
+
 class CheckMailMixin:
     "Small helper class to check sent emails easily"
 
@@ -24,6 +33,11 @@ class CheckMailMixin:
         if check_recipients is not None:
             self.assertItemsEqual(mail.partner_ids.mapped("name"), check_recipients)
         return mail
+
+    def _object_messages(self, obj):
+        return self.env["mail.message"].search(
+            [("res_id", "=", obj.id), ("model", "=", obj._name)]
+        )
 
 
 class CrmLeadShippingTC(MockedEmptySessionMixin, BaseShippingTC):
@@ -248,13 +262,9 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
             }
         )
 
-    def _last_message(self):
-        return self.env["mail.message"].search(
-            [("res_id", "=", self.lead.id), ("model", "=", "crm.lead")]
-        )[0]
-
     def check_mail_delivered(self, subject, code):
-        return self._check_mail(self._last_message(), subject, "code: " + code)
+        last_message = self._object_messages(self.lead)[0]
+        return self._check_mail(last_message, subject, "code: " + code)
 
     def test_delivery_email_template(self):
         # Shipping deactivated, template set => None expected
@@ -401,12 +411,7 @@ class CrmLeadDeliveryTrackingTC(TransactionCase, CheckMailMixin):
         trap.assert_jobs_count(len(lead_statuses))
 
         for job in trap.enqueued_jobs:
-            with patch.object(
-                DeliveryMixin,
-                "_delivery_tracking_colissimo_status",
-                side_effect=lambda *args: lead_statuses[job.recordset.name],
-            ):
-                job.perform()
+            _mock_delivery_job(job, lambda *args: lead_statuses[job.recordset.name])
 
         return leads.sorted(lambda l: list(lead_statuses.keys()).index(l.name))
 


### PR DESCRIPTION
This will hopefully avoid incidents like the one we had in January 2026 where our dedicated job queue was completely overloaded by Colissimo responding very slowly to our parcel tracking requests (they had to face a large DDOS attack).

As we do not know if the connect or the read phase time of the request was the culprit, we set both timeouts.