### PR TITLE
[16.0][IMP] commown_b2b_mail_channel / commown : New channels as groups

### DIFF
--- a/commown/views/website_portal_templates.xml
+++ b/commown/views/website_portal_templates.xml
@@ -7,7 +7,7 @@
     <xpath expr="//a[@href='/my/account']/ancestor::div[1]" position="after">
       <t
                 t-set="user_channels"
-                t-value="[c for c in user_id.partner_id.channel_ids if c.channel_type=='channel']"
+                t-value="[c for c in user_id.partner_id.channel_ids if c.channel_type=='group']"
             />
       <div class="mt-4" t-if="user_channels">
         <h4>Contact us</h4>

--- a/commown_b2b_mail_channel/models/res_partner.py
+++ b/commown_b2b_mail_channel/models/res_partner.py
@@ -11,7 +11,7 @@ class ResPartner(models.Model):
     mail_channel_id = fields.Many2one(
         "mail.channel",
         string="Support mail channel",
-        domain=[("channel_type", "=", "channel")],
+        domain=[("channel_type", "=", "group")],
     )
 
     disable_channel_subscription = fields.Boolean(
@@ -114,11 +114,13 @@ class ResPartner(models.Model):
             self.mail_channel_id = self.env["mail.channel"].create(
                 {
                     "name": "TEMP NAME",
-                    "channel_type": "channel",
+                    "channel_type": "group",
                     "partner_company": self.id,
                 }
             )
-            self.mail_channel_id.group_ids += groups_to_subscribe
+            self.mail_channel_id.add_members(
+                partner_ids=groups_to_subscribe.users.partner_id.ids
+            )
 
             # Compute name
             self.set_support_channel_name()

--- a/commown_b2b_mail_channel/tests/test_res_partner.py
+++ b/commown_b2b_mail_channel/tests/test_res_partner.py
@@ -43,14 +43,12 @@ class ResPartnerTC(TransactionCase):
         self.contract.date_start = date.today()
 
         company_chan = self.company.mail_channel_id
-        expected_group = self.b2b_chan_role.group_id
 
         self.assertEqual(company_chan.name, "Support of company %s" % self.company.name)
         self.assertEqual(
             company_chan.channel_partner_ids,
             self.part1 + self.part2 + self.user_support.partner_id,
         )
-        self.assertEqual(company_chan.group_ids, expected_group)
 
     def test_disable_automatic_subscription(self):
         self.company.disable_channel_subscription = True

--- a/commown_b2b_mail_channel/views/mail_channel.xml
+++ b/commown_b2b_mail_channel/views/mail_channel.xml
@@ -11,7 +11,7 @@
         <field
                     name="partner_company"
                     options="{'no_create': True, 'open': True}"
-                    attrs="{'invisible': [('channel_type', '!=', 'channel')]}"
+                    attrs="{'invisible': [('channel_type', '!=', 'group')]}"
                 />
       </field>
     </field>


### PR DESCRIPTION
- Changed new B2B channel creations, to set them as groups
- Display `mail_channel_id` domain on `res.partner` model to fetch `group`-type channels
- Display `partner_companies` field in `mail.channel` view if channel is a `group`-type channel
- Fetch `group`-type channels to display in customer portal