### PR TITLE
[16.0][REF] commown_shipping: Inserted default send_email_on_delivery value in create method

### DIFF
--- a/commown_shipping/models/delivery_mixin.py
+++ b/commown_shipping/models/delivery_mixin.py
@@ -86,6 +86,17 @@ class CommownTrackDeliveryMixin(models.AbstractModel):
                 parent = self.env[parent._name].browse(context[default_rel])
         return parent.default_perform_actions_on_delivery if parent else True
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        "By default, send email if parent config says to perform actions on delivery"
+        result = super().create(vals_list)
+
+        for entity, vals in zip(result, vals_list):
+            if "send_email_on_delivery" not in vals:
+                entity.send_email_on_delivery = entity._delivery_tracking_parent().default_perform_actions_on_delivery
+
+        return result
+
     def initialize_expedition_data(self, parcel_number):
         parent = self._delivery_tracking_parent()
         if parent and parent.delivery_tracking:

--- a/commown_shipping/models/delivery_mixin.py
+++ b/commown_shipping/models/delivery_mixin.py
@@ -78,12 +78,11 @@ class CommownTrackDeliveryMixin(models.AbstractModel):
     def _default_send_email_on_delivery(self):
         "By default, send email if parent config says to perform actions on delivery"
         parent = self._delivery_tracking_parent()
-        if not parent:
-            context = self.env.context
-            default_rel = "default_%s" % self._delivery_tracking_parent_rel
-            # Web UI passes default parent rel in context
-            if default_rel in context:
-                parent = self.env[parent._name].browse(context[default_rel])
+        context = self.env.context
+        default_rel = "default_%s" % self._delivery_tracking_parent_rel
+        # Web UI passes default parent rel in context
+        if default_rel in context:
+            parent = self.env[parent._name].browse(context[default_rel])
         return parent.default_perform_actions_on_delivery if parent else True
 
     @api.model_create_multi

--- a/commown_shipping/tests/test_crm_lead.py
+++ b/commown_shipping/tests/test_crm_lead.py
@@ -244,13 +244,17 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
                 ).id,
             }
         )
-        self.lead = self.env["crm.lead"].create(
-            {
-                "name": "[SO99999-01] TEST DELIVERY",
-                "partner_id": self.env.ref("base.res_partner_1").id,
-                "type": "opportunity",
-                "team_id": team.id,
-            }
+        self.lead = (
+            self.env["crm.lead"]
+            .with_context(test_commown_shipping_no_contract_check=True)
+            .create(
+                {
+                    "name": "[SO99999-01] TEST DELIVERY",
+                    "partner_id": self.env.ref("base.res_partner_1").id,
+                    "type": "opportunity",
+                    "team_id": team.id,
+                }
+            )
         )
 
     def _last_message(self):
@@ -298,7 +302,9 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
         """
         # Setup
         team = self.lead.team_id
-        lead_model = self.env["crm.lead"]
+        lead_model = self.env["crm.lead"].with_context(
+            test_commown_shipping_no_contract_check=True
+        )
 
         # Case 1: actions are enabled by default
         team.default_perform_actions_on_delivery = True
@@ -317,7 +323,12 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
         team = self.lead.team_id
 
         def assertFormSendEmailOnDelivery():
-            form = Form(self.env["crm.lead"].with_context(default_team_id=team.id))
+            form = Form(
+                self.env["crm.lead"].with_context(
+                    default_team_id=team.id,
+                    test_commown_shipping_no_contract_check=True,
+                )
+            )
             self.assertEqual(
                 form.send_email_on_delivery, team.default_perform_actions_on_delivery
             )
@@ -441,7 +452,9 @@ class CrmLeadDeliveryTrackingTC(TransactionCase, CheckMailMixin):
             }
         )
         # Imitate context passed by web UI
-        lead_model = self.env["crm.lead"].with_context(default_team_id=team.id)
+        lead_model = self.env["crm.lead"].with_context(
+            default_team_id=team.id, test_commown_shipping_no_contract_check=True
+        )
         return lead_model.create(kwargs)
 
     def test_tracked_records(self):

--- a/commown_shipping/tests/test_crm_lead.py
+++ b/commown_shipping/tests/test_crm_lead.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import requests_mock
 
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 
 from odoo.addons.commown_shipping.models.delivery_mixin import ParcelError
 from odoo.addons.commown_shipping.models.shipping_mixin import CommownShippingMixin
@@ -289,22 +289,52 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
         self.lead.team_id.delivery_tracking = False
         self.assertIsNone(self.lead.delivery_email_template())
 
-    def test_default_send_email_on_delivery_value(self):
+    def test_default_send_email_on_delivery_without_ui(self):
         """
         The default value of send_email_on_delivery should match
         the lead's team default_perform_actions_on_delivery value,
         both from the record itself, and from the context value default_team_id.
+        (Using the create method without UI)
         """
+        # Setup
         team = self.lead.team_id
-        crm_model = self.env["crm.lead"].with_context(default_team_id=team.id)
+        lead_model = self.env["crm.lead"]
 
+        # Case 1: actions are enabled by default
         team.default_perform_actions_on_delivery = True
-        self.assertTrue(crm_model._default_send_email_on_delivery())
-        self.assertTrue(self.lead._default_send_email_on_delivery())
+        lead_w_actions = lead_model.create({"name": "Lead 1", "team_id": team.id})
 
+        self.assertTrue(lead_w_actions.send_email_on_delivery)
+
+        # Case 2: actions are enabled by default
         team.default_perform_actions_on_delivery = False
-        self.assertFalse(crm_model._default_send_email_on_delivery())
-        self.assertFalse(self.lead._default_send_email_on_delivery())
+        lead_w_out_actions = lead_model.create({"name": "Lead 1", "team_id": team.id})
+
+        self.assertFalse(lead_w_out_actions.send_email_on_delivery)
+
+    def test_default_send_email_on_delivery_with_ui(self):
+        "Same as previous code, but using the web UI with the context"
+        team = self.lead.team_id
+
+        def assertFormSendEmailOnDelivery():
+            form = Form(self.env["crm.lead"].with_context(default_team_id=team.id))
+            self.assertEqual(
+                form.send_email_on_delivery, team.default_perform_actions_on_delivery
+            )
+
+            form.name = "Dummy name"
+            lead = form.save()
+            self.assertEqual(
+                lead.send_email_on_delivery, team.default_perform_actions_on_delivery
+            )
+
+        # Case 1: actions are enabled by default
+        team.default_perform_actions_on_delivery = True
+        assertFormSendEmailOnDelivery()
+
+        # Case 2: actions are disabled by default
+        team.default_perform_actions_on_delivery = False
+        assertFormSendEmailOnDelivery()
 
     def test_actions_on_delivery_send_email_team_template(self):
         self.lead.send_email_on_delivery = True

--- a/commown_shipping/tests/test_crm_lead.py
+++ b/commown_shipping/tests/test_crm_lead.py
@@ -348,7 +348,7 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
         assertFormSendEmailOnDelivery()
 
     def test_actions_on_delivery_send_email_team_template(self):
-        self.lead.send_email_on_delivery = True
+        self.assertTrue(self.lead.send_email_on_delivery)
 
         # Simulate delivery
         self.lead.expedition_status = "[LIVCFM] Test"
@@ -360,7 +360,7 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
     def test_actions_on_delivery_send_email_no_status(self):
         "Check empty expedition status is OK"
 
-        self.lead.send_email_on_delivery = True
+        self.assertTrue(self.lead.send_email_on_delivery)
 
         # Simulate delivery
         self.lead.expedition_status = False
@@ -370,7 +370,7 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
         self.check_mail_delivered("Product delivered", "EMPTY_CODE")
 
     def test_actions_on_delivery_send_email_custom_template(self):
-        self.lead.send_email_on_delivery = True
+        self.assertTrue(self.lead.send_email_on_delivery)
 
         self.lead.on_delivery_email_template_id = (
             self.lead.team_id.on_delivery_email_template_id.copy(  # noqa: B950
@@ -388,7 +388,7 @@ class CrmLeadDeliveryTC(TransactionCase, CheckMailMixin):
     def test_actions_on_delivery_send_email_no_template(self):
         "A user error must be raised in the case no template was specified"
 
-        self.lead.send_email_on_delivery = True
+        self.assertTrue(self.lead.send_email_on_delivery)
 
         self.lead.on_delivery_email_template_id = False
         self.lead.team_id.on_delivery_email_template_id = False

--- a/commown_shipping_crm_contract_delivery_mail/models/crm_lead.py
+++ b/commown_shipping_crm_contract_delivery_mail/models/crm_lead.py
@@ -12,7 +12,8 @@ class CrmLead(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         result = super().create(vals_list)
-        result.filtered(lambda lead: not lead.contract_id).write(
-            {"send_email_on_delivery": False}
-        )
+        if not self._context.get("test_commown_shipping_no_contract_check", False):
+            result.filtered(lambda lead: not lead.contract_id).write(
+                {"send_email_on_delivery": False}
+            )
         return result

--- a/commown_shipping_crm_contract_delivery_mail/tests/test_crm_lead.py
+++ b/commown_shipping_crm_contract_delivery_mail/tests/test_crm_lead.py
@@ -10,37 +10,41 @@ class CrmLeadTC(RentalSaleOrderTC):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.so = cls.create_sale_order()
-        cls.so.team_id.default_perform_actions_on_delivery = True
-        cls.so.mapped("order_line.product_id").update(
-            {"followup_sales_team_id": cls.so.team_id.id}
+        cls.so1 = cls.create_sale_order()
+        cls.so2 = cls.create_sale_order()
+
+        cls.so1.team_id.default_perform_actions_on_delivery = True
+
+        (cls.so1 | cls.so2).mapped("order_line.product_id").update(
+            {"followup_sales_team_id": cls.so1.team_id.id}
         )
 
     def test_default_action_on_delivery_with_contract(self):
-        self.so.team_id.default_perform_actions_on_delivery = True
-        lead = self._create_ra_leads(self.so).filtered("contract_id")[0]
+        # Case 1: default actions are enabled
+        self.so1.team_id.default_perform_actions_on_delivery = True
+        lead1 = self._create_ra_leads(self.so1).filtered("contract_id")[0]
 
-        self.assertTrue(lead.send_email_on_delivery)
+        self.assertTrue(lead1.send_email_on_delivery)
+
+        # Case 2: default actions are disabled
+        self.so2.team_id.default_perform_actions_on_delivery = False
+        lead2 = self._create_ra_leads(self.so2).filtered("contract_id")[0]
+
+        self.assertFalse(lead2.send_email_on_delivery)
 
     def test_default_action_on_delivery_without_contract(self):
         "Even when team perform actions on delivery"
         # Remove all contract products from sale order to get leads without a contract
-        self.so.order_line.filtered("product_id.is_contract").unlink()
+        self.so1.order_line.filtered("product_id.is_contract").unlink()
 
-        self.so.team_id.default_perform_actions_on_delivery = True
-        lead = self._create_ra_leads(self.so).filtered(lambda l: not l.contract_id)[0]
+        self.so1.team_id.default_perform_actions_on_delivery = True
+        lead = self._create_ra_leads(self.so1).filtered(lambda l: not l.contract_id)[0]
 
         self.assertFalse(lead.contract_id)  # Check pre-requisite
         self.assertFalse(lead.send_email_on_delivery)
 
         # Check delivery does not crash
         lead.delivery_date = date(2017, 1, 1)
-
-    def test_default_no_action_on_delivery(self):
-        self.so.team_id.default_perform_actions_on_delivery = False
-        lead = self._create_ra_leads(self.so)[0]
-
-        self.assertFalse(lead.send_email_on_delivery)
 
     def _create_ra_leads(self, so):
         "Confirm the sale and return all its just-created risk-analysis leads"

--- a/commown_shipping_crm_contract_delivery_mail/tests/test_crm_lead.py
+++ b/commown_shipping_crm_contract_delivery_mail/tests/test_crm_lead.py
@@ -44,5 +44,5 @@ class CrmLeadTC(RentalSaleOrderTC):
 
     def _create_ra_leads(self):
         "Confirm the sale and return all its just-created risk-analysis leads"
-        self.so.with_context(default_team_id=self.so.team_id.id).action_confirm()
+        self.so.action_confirm()
         return self.env["crm.lead"].search([("so_line_id.order_id", "=", self.so.id)])

--- a/commown_shipping_crm_contract_delivery_mail/tests/test_crm_lead.py
+++ b/commown_shipping_crm_contract_delivery_mail/tests/test_crm_lead.py
@@ -18,7 +18,7 @@ class CrmLeadTC(RentalSaleOrderTC):
 
     def test_default_action_on_delivery_with_contract(self):
         self.so.team_id.default_perform_actions_on_delivery = True
-        lead = self._create_ra_leads().filtered("contract_id")[0]
+        lead = self._create_ra_leads(self.so).filtered("contract_id")[0]
 
         self.assertTrue(lead.send_email_on_delivery)
 
@@ -28,7 +28,7 @@ class CrmLeadTC(RentalSaleOrderTC):
         self.so.order_line.filtered("product_id.is_contract").unlink()
 
         self.so.team_id.default_perform_actions_on_delivery = True
-        lead = self._create_ra_leads().filtered(lambda l: not l.contract_id)[0]
+        lead = self._create_ra_leads(self.so).filtered(lambda l: not l.contract_id)[0]
 
         self.assertFalse(lead.contract_id)  # Check pre-requisite
         self.assertFalse(lead.send_email_on_delivery)
@@ -38,11 +38,11 @@ class CrmLeadTC(RentalSaleOrderTC):
 
     def test_default_no_action_on_delivery(self):
         self.so.team_id.default_perform_actions_on_delivery = False
-        lead = self._create_ra_leads()[0]
+        lead = self._create_ra_leads(self.so)[0]
 
         self.assertFalse(lead.send_email_on_delivery)
 
-    def _create_ra_leads(self):
+    def _create_ra_leads(self, so):
         "Confirm the sale and return all its just-created risk-analysis leads"
-        self.so.action_confirm()
-        return self.env["crm.lead"].search([("so_line_id.order_id", "=", self.so.id)])
+        so.action_confirm()
+        return self.env["crm.lead"].search([("so_line_id.order_id", "=", so.id)])


### PR DESCRIPTION
Within the _default_send_email_on_delivery method, we try to access the record parent. However, since default methods are called before the actual records are created, it runs the default method on an empty record, which tries to access an empty value in _delivery_tracking_parent.

To avoid this, we instead call the _default_send_email_on_delivery method in the create method, where we have the value of the parent available, if the resource is not created through a Web UI.