### PR TITLE
[16.0][FIX] customer_team_manager/customer_device_manager: Fixed CSS classes on portal doc entries

### DIFF
--- a/customer_device_manager/views/portal_templates.xml
+++ b/customer_device_manager/views/portal_templates.xml
@@ -25,7 +25,7 @@
         Devices
         <span
                     t-esc="env['customer_device_manager.device_assignment'].search_count([('device_location', '=', 'at_customer')])"
-                    class="badge badge-secondary badge-pill"
+                    class="badge text-bg-secondary rounded-pill"
                 />
       </a>
     </xpath>

--- a/customer_team_manager/views/portal_templates.xml
+++ b/customer_team_manager/views/portal_templates.xml
@@ -18,7 +18,7 @@
             Users
             <span
                             t-esc="env['res.partner'].search_count([('customer_rank', '>', 0), ('is_company', '=', False), ('type', '=', 'contact'), ('commercial_partner_id.is_company', '=', True)])"
-                            class="badge badge-secondary badge-pill"
+                            class="badge text-bg-secondary rounded-pill"
                         />
           </a>
         </div>


### PR DESCRIPTION
# Current look
<img width="1052" height="258" alt="image" src="https://github.com/user-attachments/assets/ec372b76-a990-41a4-89b9-bc9b2f4cf254" />

# After CSS classes changes
<img width="1021" height="256" alt="image" src="https://github.com/user-attachments/assets/323c39dc-b516-4f6f-ade3-99bb4da09e78" />
