### PR TITLE
[16.0][IMP] slimpay_statements_autoimport: Added post operation on imported Slimpay statement

### DIFF
--- a/slimpay_statements_autoimport/models/statement_import.py
+++ b/slimpay_statements_autoimport/models/statement_import.py
@@ -154,6 +154,8 @@ class SlimpayStatementImport(models.Model):
         for move_line in self.imported_statement.line_ids:
             move_line.date = move_line.date_maturity
 
+        self.imported_statement.action_post()
+
     def fetch_and_import_statement(self):
         "Find the download link in the email, fetch the csv file and import it"
         doc = lxml.html.fromstring(self.mail_html)

--- a/slimpay_statements_autoimport/tests/test_statement_import.py
+++ b/slimpay_statements_autoimport/tests/test_statement_import.py
@@ -146,6 +146,7 @@ class SlimpayStatementImportTC(SlimpayStatementImportBaseTC):
         self.assertEqual(self.si.name, "my_report")
 
         move = self.si.imported_statement
+        self.assertEqual(move.state, "posted")
         self.assertTrue(all(aml.date == aml.date_maturity for aml in move.line_ids))
         self.assertEqual(move.date, date(2023, 11, 3))
 


### PR DESCRIPTION
In the bank statement reconciliation tool used in v16, provided by account_reconcile_oca, the only selectable account.move.line records are the ones of which the parent move is posted. In v12, it was possible to select move lines which were in the draft state.

As such, to allow end-users to be able to select Slimpay statement move lines from imported statements in the reconciliation view, we automatically post the account move after it's been created from an imported statement.