### PR TITLE
[16.0][IMP] customer_device_manager: Added batch creation support for customer_device_assignment.device_manager model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,7 +112,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements

--- a/customer_device_manager/models/device_assignment.py
+++ b/customer_device_manager/models/device_assignment.py
@@ -87,24 +87,27 @@ class DeviceAssignment(models.Model):
         readonly=True,
     )
 
-    @api.model
-    def create(self, values):
+    @api.model_create_multi
+    def create(self, vals_list):
         "Force first assignment history item date to the one of the assignment"
         _self = self.with_context(_in_device_assignment_creation=True)
-        rec = super(DeviceAssignment, _self).create(values)
+        records = super(DeviceAssignment, _self).create(vals_list)
 
         now = fields.Datetime.now()
         self.env["customer_device_manager.device_assignment_history"].sudo().create(
-            {
-                "assignment_id": rec.id,
-                "date": values.get("assignment_date", now),
-                "partner_id": rec.partner_id.id,
-                "device_location": rec.device_location,
-            }
+            [
+                {
+                    "assignment_id": rec.id,
+                    "date": values.get("assignment_date", now),
+                    "partner_id": rec.partner_id.id,
+                    "device_location": rec.device_location,
+                }
+                for rec, values in zip(records, vals_list)
+            ],
         )
 
         # Restore the original context in the returned result to avoid any side effect:
-        return rec.with_context(_in_device_assignment_creation=False)
+        return records.with_context(_in_device_assignment_creation=False)
 
     def _inverse_partner_id(self):
         if self._context.get("_in_device_assignment_creation", False):

--- a/customer_device_manager/models/device_assignment.py
+++ b/customer_device_manager/models/device_assignment.py
@@ -90,25 +90,30 @@ class DeviceAssignment(models.Model):
     @api.model
     def create(self, values):
         "Force first assignment history item date to the one of the assignment"
-        _self, orig_context = self, self._context
+        _self = self.with_context(_in_device_assignment_creation=True)
+        rec = super(DeviceAssignment, _self).create(values)
 
-        _date = values.get("assignment_date")
-        if _date:
-            _self = self.with_context(forced_assignment_history_date=_date)
+        now = fields.Datetime.now()
+        self.env["customer_device_manager.device_assignment_history"].sudo().create(
+            {
+                "assignment_id": rec.id,
+                "date": values.get("assignment_date", now),
+                "partner_id": rec.partner_id.id,
+                "device_location": rec.device_location,
+            }
+        )
 
         # Restore the original context in the returned result to avoid any side effect:
-        return super(DeviceAssignment, _self).create(values).with_context(orig_context)  # pylint: disable=context-overridden
+        return rec.with_context(_in_device_assignment_creation=False)
 
     def _inverse_partner_id(self):
+        if self._context.get("_in_device_assignment_creation", False):
+            return
+
         for rec in self:
-            _date = self.env.context.get(
-                "forced_assignment_history_date",
-                fields.Datetime.now(),
-            )
             self.env["customer_device_manager.device_assignment_history"].sudo().create(
                 {
                     "assignment_id": rec.id,
-                    "date": _date,
                     "partner_id": rec.partner_id.id,
                     "device_location": rec.device_location,
                 }


### PR DESCRIPTION
Potential issues with this implementation :
- If several device assignments are created at once with the same device and partner, but different assignments dates, then the history will only use one of these dates.