### PR TITLE
[16.0][FIX] commown_devices: Assign default recurring invoicing date to created contract

### DIFF
--- a/commown_devices/models/wizard_project_task_to_employee.py
+++ b/commown_devices/models/wizard_project_task_to_employee.py
@@ -94,6 +94,7 @@ class ProjectTaskDeviceToEmployeeWizard(models.TransientModel):
                 "name": cname % {"product": pt.name, "partner": partner.name},
                 "contract_template_id": ct.id,
                 "partner_id": partner.id,
+                "recurring_next_date": fields.Datetime.now(),
             }
         )
         contract._onchange_contract_template_id()

--- a/commown_devices/tests/test_wizard_to_employee.py
+++ b/commown_devices/tests/test_wizard_to_employee.py
@@ -1,6 +1,7 @@
 import requests_mock
 
 from odoo.exceptions import UserError
+from odoo.fields import Command
 
 from odoo.addons.commown_shipping.tests.common import BaseShippingTC
 
@@ -27,6 +28,10 @@ class WizardToEmployeeTC(BaseWizardToEmployeeMixin, BaseShippingTC):
             {"name": "FP3", "type": "product", "tracking": "serial"}
         )
         cls.lot = create_lot_and_quant(cls.env, "fp3_1", pt.product_variant_id, cls.loc)
+
+        # Add a line to the employee contract template, to more closely ressemble the production's template
+        ct = cls.env.ref("commown_devices.contract_template_to_employee")
+        ct.contract_line_ids = [Command.create({"name": "Dummy employee line"})]
 
     def get_wizard(self, **kwargs):
         kwargs.setdefault("lot_id", self.lot.id)


### PR DESCRIPTION
At contract creation, the recurring_next_date field is computed from the contract lines (see contract/models/contract.py:L318). However, since the contract we create has line_recurrence disabled by default, the contract lines assign the contract's recurring next date field to themselves (see contract/models/abstract_contract_line.py:L143)

Since we don't specifically aim to track invoicing on a per-line basis, we fix this issue by assigning a default recurring_next_date field to the created contract.