### PR TITLE
[16.0][FIX] commown_shipping: Replaced soft_reload action by reload

### DIFF
--- a/commown_shipping/models/wizard_print_label.py
+++ b/commown_shipping/models/wizard_print_label.py
@@ -33,7 +33,9 @@ class ProjectTaskAbstractPrintLabelWizard(models.AbstractModel):
                     "target": "current",
                 },
                 {"type": "ir.actions.act_window_close"},
-                {"type": "ir.actions.client", "tag": "soft_reload"},
+                {"type": "ir.actions.client", "tag": "reload"},
+                # 'soft_reload' replaced by 'reload temporarily.
+                # (see https://github.com/odoo/odoo/issues/256020)
             ],
         }
 

--- a/commown_shipping/tests/common.py
+++ b/commown_shipping/tests/common.py
@@ -99,7 +99,7 @@ class BaseShippingTC(TransactionCase):
         )
         self.assertEqual(
             [a for a in actions if a["type"] == "ir.actions.client"][0]["tag"],
-            "soft_reload",
+            "reload",
         )
 
         return self._attachment_from_download_action(action_multi["actions"][0])


### PR DESCRIPTION
When using soft_reload, the given page is reloaded with the res id stored in the JS controller state. However, it is not updated before calling the reload, even when going to a new page. This can lead to a previous task id being used, and as such, ending up on a previous page page. (see https://github.com/odoo/odoo/issues/256020 )

To circumvent this, we swap the soft_reload action by the reload action, which is based on the URL of the page.