### PR TITLE
[16.0][IMP] commown_cooperative_campaign: Added sudo access to ir.config_parameter for campaign base_url for contract operations

### DIFF
--- a/commown_cooperative_campaign/models/contract.py
+++ b/commown_cooperative_campaign/models/contract.py
@@ -51,8 +51,10 @@ class Contract(models.Model):
 
     def _coop_ws_optout(self, campaign, customer_key, date_end, tz):
         self.ensure_one()
-        url = self.env["ir.config_parameter"].get_param(
-            "commown_cooperative_campaign.base_url"
+        url = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("commown_cooperative_campaign.base_url")
         )
         coop_ws_optout(url, campaign.name, customer_key, date_end, tz)
 

--- a/commown_cooperative_campaign/models/discount.py
+++ b/commown_cooperative_campaign/models/discount.py
@@ -135,8 +135,10 @@ class ContractAbstractDiscountLine(models.AbstractModel):
                     )
                     if len(emitted_invoices) == 0:
                         # Contract start invoice: optin to the campaign
-                        url = self.env["ir.config_parameter"].get_param(
-                            "commown_cooperative_campaign.base_url"
+                        url = (
+                            self.env["ir.config_parameter"]
+                            .sudo()
+                            .get_param("commown_cooperative_campaign.base_url")
                         )
                         coop_ws_optin(
                             url,
@@ -177,8 +179,10 @@ class ContractAbstractDiscountLine(models.AbstractModel):
                 if not identifier:
                     return False
 
-                url = self.env["ir.config_parameter"].get_param(
-                    "commown_cooperative_campaign.base_url"
+                url = (
+                    self.env["ir.config_parameter"]
+                    .sudo()
+                    .get_param("commown_cooperative_campaign.base_url")
                 )
 
                 result = coop_ws_query(url, campaign.name, identifier, date)


### PR DESCRIPTION
Since these methods can be called from the web client (from recurring_next_invoice on a contract, or applying date_end), these access triggered an AccessError if the user wasn't an admin.

As such, we provide a temporary superuser access to fetch the campaign's base url.