### PR TITLE
[16.0][CI] Updated setuptools-odoo version to 3.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,7 +112,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements


### PR DESCRIPTION
This versions locks the version of setuptools to a version prior to 82, which removes pkg_resources being used in setuptools-odoo -> https://github.com/acsone/setuptools-odoo/commit/381fb71b077cee08f7bf492ae769cf1564a446b5