### PR TITLE
[16.0][IMP] commown_contract_forecast: Replaced default filter context for date_invoice groupby

### DIFF
--- a/commown_contract_forecast/views/contract_line_forecast_period.xml
+++ b/commown_contract_forecast/views/contract_line_forecast_period.xml
@@ -11,4 +11,22 @@
     </field>
   </record>
 
+  <record id="forecast_view_search" model="ir.ui.view">
+    <field
+            name="name"
+        >contract.line.forecast.period.search (in commown_contract_forecast)</field>
+    <field name="model">contract.line.forecast.period</field>
+    <field
+            name="inherit_id"
+            ref="contract_forecast.contract_line_forecast_period_search_view"
+        />
+    <field name="arch" type="xml">
+      <filter name="groupby_date_invoice" position="attributes">
+        <!-- Replace 'date_invoice:day' by 'date_invoice:month'-->
+        <attribute name="context">{'group_by':'date_invoice:month'}</attribute>
+      </filter>
+    </field>
+  </record>
+
+
 </odoo>


### PR DESCRIPTION
When opening the contract forecast action, the groupby_date_invoice is applied by default, which is set to group per day. see following :
-> 'groupby_date_invoice' filter in contract_forecast/views/contract_line_forecast_period.xml:L27 -> 'action_show_contract_forecast' method in contract_forecast/models/contract.py:L11

However, when rendering the amounts as a graph, that means each day is displayed on the row axis, rendering the columns for each invoicing thin, and as such hard to see.

To circumvent this, since we typically invoice contracts once per month, we swapped the default granularity from days to months.

### Render of the graph view
<img width="551" height="934" alt="image" src="https://github.com/user-attachments/assets/a6915f00-01dd-42d4-8c48-6dfe7b55115b" />