### PR TITLE
[16.0][FIX] commown: Migrated account.move template for contract auto-payment

### DIFF
--- a/commown/data/mail_templates.xml
+++ b/commown/data/mail_templates.xml
@@ -6,23 +6,23 @@
     <field name="reply_to">contact@commown.fr</field>
     <field
             name="subject"
-        >[{{object.company_id.name}}] Facture (Ref {{object.number or 'n/a'}})</field>
+        >[{{object.company_id.name}}] Facture (Ref {{object.name or 'n/a'}})</field>
     <field name="partner_to">{{object.partner_id.id}}</field>
     <field name="model_id" ref="account.model_account_move" />
     <field name="auto_delete" eval="True" />
     <field name="report_template" ref="account.account_invoices" />
     <field
             name="report_name"
-        >Commown_Facture_{{(object.number or '').replace('/','_')}}_{{object.state == 'draft' and 'draft' or ''}}</field>
+        >Commown_Facture_{{(object.name or '').replace('/','_')}}_{{object.state == 'draft' and 'draft' or ''}}</field>
     <field name="lang">{{object.partner_id.lang}}</field>
     <field
             name="body_html"
         ><![CDATA[
 <p>Bonjour <t t-out="object.partner_id.firstname" />,</p>
 <br/>
-<p>Votre facture <strong><t t-out="object.number" /></strong>
-<t t-if="object.origin" >
-(référence : <t t-out="object.origin" /> )
+<p>Votre facture <strong><t t-out="object.name" /></strong>
+<t t-if="object.invoice_origin" >
+(référence : <t t-out="object.invoice_origin" /> )
 </t>
 d'un montant de <strong><t t-out="object.amount_total" /> <t t-out="object.currency_id.symbol" /></strong> est disponible dans votre espace Commown.</p>
 

--- a/commown/i18n/commown.pot
+++ b/commown/i18n/commown.pot
@@ -72,9 +72,9 @@ msgid ""
 "<html>\n"
 "  <body><p>Bonjour <t t-out=\"object.partner_id.firstname\"></t>,</p>\n"
 "<br/>\n"
-"<p>Votre facture <strong><t t-out=\"object.number\"></t></strong>\n"
-"<t t-if=\"object.origin\">\n"
-"(référence : <t t-out=\"object.origin\"></t> )\n"
+"<p>Votre facture <strong><t t-out=\"object.name\"></t></strong>\n"
+"<t t-if=\"object.invoice_origin\">\n"
+"(référence : <t t-out=\"object.invoice_origin\"></t> )\n"
 "</t>\n"
 "d'un montant de <strong><t t-out=\"object.amount_total\"></t> <t t-out=\"object.currency_id.symbol\"></t></strong> est disponible dans votre espace Commown.</p>\n"
 "\n"
@@ -139,7 +139,7 @@ msgstr ""
 #. module: commown
 #: model:mail.template,report_name:commown.email_send_invoice_from_contract
 msgid ""
-"Commown_Facture_{{(object.number or '').replace('/','_')}}_{{object.state =="
+"Commown_Facture_{{(object.name or '').replace('/','_')}}_{{object.state =="
 " 'draft' and 'draft' or ''}}"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 
 #. module: commown
 #: model:mail.template,subject:commown.email_send_invoice_from_contract
-msgid "[{{object.company_id.name}}] Facture (Ref {{object.number or 'n/a'}})"
+msgid "[{{object.company_id.name}}] Facture (Ref {{object.name or 'n/a'}})"
 msgstr ""
 
 #. module: commown

--- a/commown/i18n/de.po
+++ b/commown/i18n/de.po
@@ -83,9 +83,9 @@ msgid ""
 "<html>\n"
 "  <body><p>Bonjour <t t-out=\"object.partner_id.firstname\"></t>,</p>\n"
 "<br/>\n"
-"<p>Votre facture <strong><t t-out=\"object.number\"></t></strong>\n"
-"<t t-if=\"object.origin\">\n"
-"(référence : <t t-out=\"object.origin\"></t> )\n"
+"<p>Votre facture <strong><t t-out=\"object.name\"></t></strong>\n"
+"<t t-if=\"object.invoice_origin\">\n"
+"(référence : <t t-out=\"object.invoice_origin\"></t> )\n"
 "</t>\n"
 "d'un montant de <strong><t t-out=\"object.amount_total\"></t> <t t-"
 "out=\"object.currency_id.symbol\"></t></strong> est disponible dans votre "
@@ -156,7 +156,7 @@ msgstr "Schließen"
 #. module: commown
 #: model:mail.template,report_name:commown.email_send_invoice_from_contract
 msgid ""
-"Commown_Facture_{{(object.number or '').replace('/','_')}}_{{object.state == "
+"Commown_Facture_{{(object.name or '').replace('/','_')}}_{{object.state == "
 "'draft' and 'draft' or ''}}"
 msgstr ""
 
@@ -601,7 +601,7 @@ msgstr "[commown] Diesen Partner als Vertragspartner seiner Firma festlegen"
 
 #. module: commown
 #: model:mail.template,subject:commown.email_send_invoice_from_contract
-msgid "[{{object.company_id.name}}] Facture (Ref {{object.number or 'n/a'}})"
+msgid "[{{object.company_id.name}}] Facture (Ref {{object.name or 'n/a'}})"
 msgstr ""
 
 #. module: commown

--- a/commown/i18n/fr.po
+++ b/commown/i18n/fr.po
@@ -83,9 +83,9 @@ msgid ""
 "<html>\n"
 "  <body><p>Bonjour <t t-out=\"object.partner_id.firstname\"></t>,</p>\n"
 "<br/>\n"
-"<p>Votre facture <strong><t t-out=\"object.number\"></t></strong>\n"
-"<t t-if=\"object.origin\">\n"
-"(référence : <t t-out=\"object.origin\"></t> )\n"
+"<p>Votre facture <strong><t t-out=\"object.name\"></t></strong>\n"
+"<t t-if=\"object.invoice_origin\">\n"
+"(référence : <t t-out=\"object.invoice_origin\"></t> )\n"
 "</t>\n"
 "d'un montant de <strong><t t-out=\"object.amount_total\"></t> <t t-"
 "out=\"object.currency_id.symbol\"></t></strong> est disponible dans votre "
@@ -156,7 +156,7 @@ msgstr "Fermer"
 #. module: commown
 #: model:mail.template,report_name:commown.email_send_invoice_from_contract
 msgid ""
-"Commown_Facture_{{(object.number or '').replace('/','_')}}_{{object.state == "
+"Commown_Facture_{{(object.name or '').replace('/','_')}}_{{object.state == "
 "'draft' and 'draft' or ''}}"
 msgstr ""
 
@@ -594,7 +594,7 @@ msgstr "[commown] Choisir comme partenaire des contrats de sa société"
 
 #. module: commown
 #: model:mail.template,subject:commown.email_send_invoice_from_contract
-msgid "[{{object.company_id.name}}] Facture (Ref {{object.number or 'n/a'}})"
+msgid "[{{object.company_id.name}}] Facture (Ref {{object.name or 'n/a'}})"
 msgstr ""
 
 #. module: commown


### PR DESCRIPTION
- "number" -> "name"
- "origin" -> "invoice_origin"

(this template is only used on 10 contracts, and has been fixed in the database)