### PR TITLE
[16.0][FIX] mail_thread_redirect_to_channel: Replaced body argument usage by posted message HTML body

### DIFF
--- a/mail_thread_redirect_to_channel/models/mail_thread.py
+++ b/mail_thread_redirect_to_channel/models/mail_thread.py
@@ -16,11 +16,11 @@ class MailThread(models.AbstractModel):
             }
         )
 
-    def message_post(self, *args, body="", **kwargs):
-        res = super().message_post(*args, body=body, **kwargs)
+    def message_post(self, *args, **kwargs):
+        res = super().message_post(*args, **kwargs)
         if res.message_type in ("email", "comment") and res:
             origin_thread_link = _("(from %s)", self._get_origin_thread_link_element())
-            channel_body = Markup(origin_thread_link + "<br/><br/>") + body
+            channel_body = Markup(origin_thread_link + "<br/><br/>") + res.body
 
             redirects = (
                 self.env["mail.thread.redirect"]

--- a/mail_thread_redirect_to_channel/tests/test_mail_redirect.py
+++ b/mail_thread_redirect_to_channel/tests/test_mail_redirect.py
@@ -82,6 +82,17 @@ class MailThreadRedirectTC(TransactionCase):
         expected_link = f"/web#model={self.dummy_1._name}&amp;id={self.dummy_1.id}"
         self.assertIn(expected_link, chan_message.body)
 
+    def test_redirect_with_markup_body(self):
+        "The body of the channel post should be properly transcribed"
+        body_w_tags = "<b>Redirect with HTML tag</b>"
+
+        self._post_message(self.dummy_1, body_w_tags, self.user_internal)
+
+        chan_message = self.channel.message_ids
+        self.assertEqual(len(chan_message), 1)
+
+        self.assertIn(body_w_tags, chan_message.body)
+
     def test_redirect_only_portal_users(self):
         # Case 1: Only portal user messages are redirected
         self.redirect.only_portal_users = True


### PR DESCRIPTION
The 'body' argument passed to message_post might be a regular string, which when concatenated to a markup variable can lead to some elements, such as brackets ('<', '>') to be replaced by their litteral character ('&lt;', '&gt;'), and as such not be interpreted as markup tags.

However, the 'body' field of the created mail.message is an HTML field, which means its been parsed as an markup block already.

As such, we use its body to append to the generated link to the original resource, which won't lead to unreadable bodies of text in the redirected message.