### PR TITLE
Improve invoice table on rental fees computation form view

### DIFF
--- a/rental_fees/views/rental_fees_computation.xml
+++ b/rental_fees/views/rental_fees_computation.xml
@@ -216,18 +216,19 @@
           <group name="invoices" attrs="{'invisible': [('state', '!=', 'done')]}">
             <field name="invoice_ids" widget="many2many">
               <tree
-                                decoration-muted="state == 'cancel'"
+                                decoration-muted="state != 'posted'"
                                 decoration-it="state == 'posted'"
-                                decoration-warning="state == 'paid' and move_type in ('in_invoice', 'out_refund')"
-                                decoration-success="state == 'paid' and move_type not in ('in_invoice', 'out_refund')"
+                                decoration-warning="payment_state == 'paid' and move_type in ('in_invoice', 'out_refund')"
+                                decoration-success="payment_state == 'paid' and move_type not in ('in_invoice', 'out_refund')"
                             >
                 <field name="move_type" />
                 <field name="invoice_date" />
                 <field name="name" />
+                <field name="ref" />
                 <field name="amount_untaxed" />
-                <field name="amount_total" />
                 <field name="amount_residual" />
-                <field name="state" />
+                <field name="payment_state" invisible="1" />
+                <field name="state" invisible="1" />
               </tree>
             </field>
           </group>


### PR DESCRIPTION
Since there are now two interesting state fields for an invoice (state and payment_state) we use them to display each line. Also we add the ref invoice field in the table (which was displayed in v12 and is important, without removing the name, which is also interesting to see. However the states are no logner displayed as the amount_residual is enough. We do no longer display the amount_total as the fees are paid by companies, without taxes.