### PR TITLE
[FIX] commown_shipping: Increased timeout value for label generation request

### DIFF
--- a/commown_shipping/models/colissimo_utils.py
+++ b/commown_shipping/models/colissimo_utils.py
@@ -19,7 +19,7 @@ BASE_URL = "https://ws.colissimo.fr/sls-ws/SlsServiceWSRest"
 
 MAX_ADDRESS_SIZE_COLISSIMO = 35
 
-TIMEOUT = 10
+TIMEOUT = 20
 
 
 class ColissimoError(Exception):


### PR DESCRIPTION
When generating a relatively high amount of labels at once, from several leads, the connection to the Colissimo servers lengthens, leading to a timeout response and failing the mass label generation.

As such, we increase the TIMEOUT value from 10 to 20 seconds, to offer more time to generate labels if the amount of requested labels is high.