### PR TITLE
[16.0][FIX] commown_self_troubleshooting: Fixed wrong FP3 model name translation

### DIFF
--- a/commown_self_troubleshooting/data/Assistance/Generic_Issue/form.xml
+++ b/commown_self_troubleshooting/data/Assistance/Generic_Issue/form.xml
@@ -42,7 +42,10 @@
           </script>
 
           <t t-set="issue_title">Demande d'assistance</t>
-          <t t-set="issue_description_template">issue-description-generic-issue</t>
+          <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-generic-issue'"
+                    />
           <!-- Fin des variables à modifier -->
 
           <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/Assistance/Serenity/form.xml
+++ b/commown_self_troubleshooting/data/Assistance/Serenity/form.xml
@@ -18,7 +18,10 @@
 
           <t t-set="tag_names">Sérénité</t>
           <t t-set="issue_title">Option Sérénité - M'appeler</t>
-          <t t-set="issue_description_template">issue-description-serenity</t>
+          <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-serenity'"
+                    />
           <!-- Fin des variables à modifier -->
 
           <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/CC/screen/form.xml
+++ b/commown_self_troubleshooting/data/CC/screen/form.xml
@@ -8,8 +8,8 @@
     <field name="arch" type="xml">
       <t t-name="website.self-troubleshoot-crosscall-screen">
         <t t-call="website.self-troubleshoot-smartphone-screen">
-          <t t-set="model">Crosscall</t>
-          <t t-set="screwdriver_codename">None</t>
+          <t t-set="model" t-value="'Crosscall'" />
+          <t t-set="screwdriver_codename" t-value="None" />
         </t>
       </t>
     </field>

--- a/commown_self_troubleshooting/data/Commercial/form.xml
+++ b/commown_self_troubleshooting/data/Commercial/form.xml
@@ -22,7 +22,10 @@
           </script>
 
           <t t-set="issue_title">Demande commerciale</t>
-          <t t-set="issue_description_template">issue-description-commercial</t>
+          <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-commercial'"
+                    />
 
           <div class="bg-white border m-0 p-3 rounded">
             <h1>Demandes Commerciales</h1>

--- a/commown_self_troubleshooting/data/ContractManagement/termination/form.xml
+++ b/commown_self_troubleshooting/data/ContractManagement/termination/form.xml
@@ -44,7 +44,8 @@
           <t t-set="issue_title">Résiliation</t>
           <t
                         t-set="issue_description_template"
-                    >issue-description-contract-termination</t>
+                        t-value="'issue-description-contract-termination'"
+                    />
           <!-- Fin des variables à modifier -->
 
           <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/ContractManagement/theftandloss/form.xml
+++ b/commown_self_troubleshooting/data/ContractManagement/theftandloss/form.xml
@@ -47,7 +47,10 @@
           </script>
 
           <t t-set="title">Commown - Vie de mes contrats - Vol ou Perte</t>
-          <t t-set="issue_description_template">issue-description-theft-and-loss</t>
+          <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-theft-and-loss'"
+                    />
           <!-- Fin des variables à modifier -->
 
           <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/FP2/battery/form.xml
+++ b/commown_self_troubleshooting/data/FP2/battery/form.xml
@@ -28,7 +28,10 @@
             <!-- Variables à modifier ici -->
             <t t-set="tag_names">Appareil FP2,FP MOD batterie</t>
             <t t-set="issue_title">FP2 - Batterie</t>
-            <t t-set="issue_description_template">issue-description-fp2-battery</t>
+            <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-fp2-battery'"
+                    />
             <!-- Fin des variables à modifier -->
 
             <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/FP2/camera/form.xml
+++ b/commown_self_troubleshooting/data/FP2/camera/form.xml
@@ -216,7 +216,7 @@
 
                     <t t-call="commown_self_troubleshooting.step-confirm-module-change">
                       <t t-set="step">4</t>
-                      <t t-set="screwdriver_codename">PH00</t>
+                      <t t-set="screwdriver_codename" t-value="'PH00'" />
                     </t>
 
                     <t t-call="commown_self_troubleshooting.step-self-solved">

--- a/commown_self_troubleshooting/data/FP2/camera/form.xml
+++ b/commown_self_troubleshooting/data/FP2/camera/form.xml
@@ -34,7 +34,10 @@
             <!-- Variables à modifier ici -->
             <t t-set="tag_names">Appareil FP2,FP MOD caméra</t>
             <t t-set="issue_title">FP2 - Caméra</t>
-            <t t-set="issue_description_template">issue-description-fp2-camera</t>
+            <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-fp2-camera'"
+                    />
             <!-- Fin des variables à modifier -->
 
             <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/FP2/micro/form.xml
+++ b/commown_self_troubleshooting/data/FP2/micro/form.xml
@@ -297,7 +297,7 @@
 
                     <t t-call="commown_self_troubleshooting.step-confirm-module-change">
                       <t t-set="step">5</t>
-                      <t t-set="screwdriver_codename">PH00</t>
+                      <t t-set="screwdriver_codename" t-value="'PH00'" />
                     </t>
 
                     <t t-call="commown_self_troubleshooting.step-self-solved">

--- a/commown_self_troubleshooting/data/FP2/micro/form.xml
+++ b/commown_self_troubleshooting/data/FP2/micro/form.xml
@@ -39,7 +39,10 @@
             <!-- Variables à modifier ici -->
             <t t-set="tag_names">Appareil FP2,FP MOD micro</t>
             <t t-set="issue_title">FP2 - Micro</t>
-            <t t-set="issue_description_template">issue-description-fp2-micro</t>
+            <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-fp2-micro'"
+                    />
             <t
                         t-set="stage_long_term_followup"
                         t-value="env.ref('commown_support.stage_long_term_followup').id"

--- a/commown_self_troubleshooting/data/FP3/display/form.xml
+++ b/commown_self_troubleshooting/data/FP3/display/form.xml
@@ -32,7 +32,10 @@
           <!-- Variables à modifier ici -->
           <t t-set="tag_names">FP MOD ecran</t>
           <t t-set="issue_title">FP3 - Écran </t>
-          <t t-set="issue_description_template">issue-description-fp3-display</t>
+          <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-fp3-display'"
+                    />
           <!-- Fin des variables à modifier -->
 
           <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/FP3/display/form.xml
+++ b/commown_self_troubleshooting/data/FP3/display/form.xml
@@ -125,7 +125,7 @@
 
                   <t t-call="commown_self_troubleshooting.step-manipulation-option">
                     <t t-set="step">1</t>
-                    <t t-set="screwdriver_codename">PH00</t>
+                    <t t-set="screwdriver_codename" t-value="'PH00'" />
                   </t>
 
                     <div

--- a/commown_self_troubleshooting/data/FP3/screen/form.xml
+++ b/commown_self_troubleshooting/data/FP3/screen/form.xml
@@ -8,8 +8,8 @@
     <field name="arch" type="xml">
       <t t-name="website.self-troubleshoot-fp3-screen">
         <t t-call="website.self-troubleshoot-smartphone-screen">
-          <t t-set="model">FP3</t>
-          <t t-set="screwdriver_codename">PH00</t>
+          <t t-set="model" t-value="'FP3'" />
+          <t t-set="screwdriver_codename" t-value="'PH00'" />
         </t>
       </t>
     </field>

--- a/commown_self_troubleshooting/data/FP4/screen/form.xml
+++ b/commown_self_troubleshooting/data/FP4/screen/form.xml
@@ -8,8 +8,8 @@
     <field name="arch" type="xml">
       <t t-name="website.self-troubleshoot-fp4-screen">
         <t t-call="website.self-troubleshoot-smartphone-screen">
-          <t t-set="model">FP4</t>
-          <t t-set="screwdriver_codename">PH00</t>
+          <t t-set="model" t-value="'FP4'" />
+          <t t-set="screwdriver_codename" t-value="'PH00'" />
         </t>
       </t>
     </field>

--- a/commown_self_troubleshooting/data/FP5/screen/form.xml
+++ b/commown_self_troubleshooting/data/FP5/screen/form.xml
@@ -8,8 +8,8 @@
     <field name="arch" type="xml">
       <t t-name="website.self-troubleshoot-fp5-screen">
         <t t-call="website.self-troubleshoot-smartphone-screen">
-          <t t-set="model">FP5</t>
-          <t t-set="screwdriver_codename">PH00</t>
+          <t t-set="model" t-value="'FP5'" />
+          <t t-set="screwdriver_codename" t-value="'PH00'" />
         </t>
       </t>
     </field>

--- a/commown_self_troubleshooting/data/GS/day/form.xml
+++ b/commown_self_troubleshooting/data/GS/day/form.xml
@@ -51,7 +51,7 @@
             <!-- Variables à modifier ici -->
             <t t-set="tag_names">Appareil GS Day</t>
             <t t-set="issue_title">Casque DAY - Son</t>
-            <t t-set="issue_description_template">issue-description-gs</t>
+            <t t-set="issue_description_template" t-value="'issue-description-gs'" />
             <!-- Fin des variables à modifier -->
 
             <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/Other/other/form.xml
+++ b/commown_self_troubleshooting/data/Other/other/form.xml
@@ -16,7 +16,7 @@
           </script>
 
           <t t-set="issue_title">Demande spéciale</t>
-          <t t-set="issue_description_template">issue-description-other</t>
+          <t t-set="issue_description_template" t-value="'issue-description-other'" />
           <!-- Fin des variables à modifier -->
 
           <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/data/Shiftphone/screen/form.xml
+++ b/commown_self_troubleshooting/data/Shiftphone/screen/form.xml
@@ -8,8 +8,8 @@
     <field name="arch" type="xml">
       <t t-name="website.self-troubleshoot-shiftphone-screen">
         <t t-call="website.self-troubleshoot-smartphone-screen">
-          <t t-set="model">Shiftphone</t>
-          <t t-set="screwdriver_codename">T3</t>
+          <t t-set="model" t-value="'Shiftphone'" />
+          <t t-set="screwdriver_codename" t-value="'T3'" />
         </t>
       </t>
     </field>

--- a/commown_self_troubleshooting/data/Smartphone/screen/form.xml
+++ b/commown_self_troubleshooting/data/Smartphone/screen/form.xml
@@ -40,7 +40,10 @@
         <t t-set="issue_title"><t
                             t-esc="model"
                         /> - Changement d'écran et/ou vitre de protection</t>
-        <t t-set="issue_description_template">issue-description-smartphone-screen</t>
+        <t
+                        t-set="issue_description_template"
+                        t-value="'issue-description-smartphone-screen'"
+                    />
         <!-- Fin des variables à modifier -->
 
         <div class="bg-white border m-0 p-3 rounded">

--- a/commown_self_troubleshooting/i18n/commown_self_troubleshooting.pot
+++ b/commown_self_troubleshooting/i18n/commown_self_troubleshooting.pot
@@ -850,7 +850,6 @@ msgstr ""
 #. module: commown_self_troubleshooting
 #: model:commown_self_troubleshooting.category,name:commown_self_troubleshooting.crosscall-ts-cat
 #: model:ir.ui.view,website_meta_title:commown_self_troubleshooting.crosscall-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.crosscall-screen
 msgid "Crosscall"
 msgstr ""
 
@@ -1096,24 +1095,10 @@ msgstr ""
 msgid "FP2 - Micro"
 msgstr ""
 
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-screen
-msgid "FP3"
-msgstr ""
 
 #. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-display
 msgid "FP3 - Écran"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp4-screen
-msgid "FP4"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp5-screen
-msgid "FP5"
 msgstr ""
 
 #. module: commown_self_troubleshooting
@@ -1666,16 +1651,6 @@ msgid "Oui"
 msgstr ""
 
 #. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-camera
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-display
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp4-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp5-screen
-msgid "PH00"
-msgstr ""
-
-#. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
 msgid ""
 "Pendant le test, tenez le téléphone comme si vous appeliez, et parlez. Vous "
@@ -1798,7 +1773,6 @@ msgstr ""
 #. module: commown_self_troubleshooting
 #: model:commown_self_troubleshooting.category,name:commown_self_troubleshooting.shiftphone-ts-cat
 #: model:ir.ui.view,website_meta_title:commown_self_troubleshooting.shiftphone-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.shiftphone-screen
 msgid "Shiftphone"
 msgstr ""
 
@@ -1846,11 +1820,6 @@ msgstr ""
 #: model:project.tags,name:commown_self_troubleshooting.tag-to-callback
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.serenity
 msgid "Sérénité"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.shiftphone-screen
-msgid "T3"
 msgstr ""
 
 #. module: commown_self_troubleshooting
@@ -2160,66 +2129,6 @@ msgstr ""
 #. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.step-contract-choice
 msgid "ici pour les ordinateurs  <i class=\"fa fa-external-link-alt\"/>"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.commercial
-msgid "issue-description-commercial"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.contract-termination
-msgid "issue-description-contract-termination"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-battery
-msgid "issue-description-fp2-battery"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-camera
-msgid "issue-description-fp2-camera"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
-msgid "issue-description-fp2-micro"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-display
-msgid "issue-description-fp3-display"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.generic-issue
-msgid "issue-description-generic-issue"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.gs-day
-msgid "issue-description-gs"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.other
-msgid "issue-description-other"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.serenity
-msgid "issue-description-serenity"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.smartphone-screen
-msgid "issue-description-smartphone-screen"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.theft-and-loss
-msgid "issue-description-theft-and-loss"
 msgstr ""
 
 #. module: commown_self_troubleshooting

--- a/commown_self_troubleshooting/i18n/de.po
+++ b/commown_self_troubleshooting/i18n/de.po
@@ -1139,7 +1139,6 @@ msgstr "Erstellt am:"
 #. module: commown_self_troubleshooting
 #: model:commown_self_troubleshooting.category,name:commown_self_troubleshooting.crosscall-ts-cat
 #: model:ir.ui.view,website_meta_title:commown_self_troubleshooting.crosscall-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.crosscall-screen
 msgid "Crosscall"
 msgstr "Crosscall"
 
@@ -2170,16 +2169,6 @@ msgid "Oui"
 msgstr "Ja"
 
 #. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-camera
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-display
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp4-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp5-screen
-msgid "PH00"
-msgstr "PH00"
-
-#. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
 msgid ""
 "Pendant le test, tenez le téléphone comme si vous appeliez, et parlez. Vous "
@@ -2323,7 +2312,6 @@ msgstr "Reihenfolge"
 #. module: commown_self_troubleshooting
 #: model:commown_self_troubleshooting.category,name:commown_self_troubleshooting.shiftphone-ts-cat
 #: model:ir.ui.view,website_meta_title:commown_self_troubleshooting.shiftphone-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.shiftphone-screen
 msgid "Shiftphone"
 msgstr "Shiftphone"
 
@@ -2398,11 +2386,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.serenity
 msgid "Sérénité"
 msgstr "Serenity (Garantierte Gelassenheit)"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.shiftphone-screen
-msgid "T3"
-msgstr "T3"
 
 #. module: commown_self_troubleshooting
 #: model:ir.model.fields,help:commown_self_troubleshooting.field_commown_self_troubleshooting_item__link_url
@@ -2807,66 +2790,6 @@ msgstr "hier <i class=\"fas fa-external-link-alt\"/>"
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.step-contract-choice
 msgid "ici pour les ordinateurs  <i class=\"fa fa-external-link-alt\"/>"
 msgstr "hier für Computer <i class=\"fa fa-external-link-alt\"/>"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.commercial
-msgid "issue-description-commercial"
-msgstr "issue-description-commercial"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.contract-termination
-msgid "issue-description-contract-termination"
-msgstr "issue-description-contract-termination"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-battery
-msgid "issue-description-fp2-battery"
-msgstr "issue-description-fp2-battery"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-camera
-msgid "issue-description-fp2-camera"
-msgstr "issue-description-fp2-camera"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
-msgid "issue-description-fp2-micro"
-msgstr "issue-description-fp2-micro"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-display
-msgid "issue-description-fp3-display"
-msgstr "issue-description-fp3-display"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.generic-issue
-msgid "issue-description-generic-issue"
-msgstr "issue-description-generic-issue"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.gs-day
-msgid "issue-description-gs"
-msgstr "issue-description-gs"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.other
-msgid "issue-description-other"
-msgstr "issue-description-other"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.serenity
-msgid "issue-description-serenity"
-msgstr "issue-description-serenity"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.smartphone-screen
-msgid "issue-description-smartphone-screen"
-msgstr "issue-description-smartphone-screen"
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.theft-and-loss
-msgid "issue-description-theft-and-loss"
-msgstr "issue-description-theft-and-loss"
 
 #. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.issue-description-fp2-camera

--- a/commown_self_troubleshooting/i18n/fr.po
+++ b/commown_self_troubleshooting/i18n/fr.po
@@ -922,7 +922,6 @@ msgstr "Créé le"
 #. module: commown_self_troubleshooting
 #: model:commown_self_troubleshooting.category,name:commown_self_troubleshooting.crosscall-ts-cat
 #: model:ir.ui.view,website_meta_title:commown_self_troubleshooting.crosscall-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.crosscall-screen
 msgid "Crosscall"
 msgstr ""
 
@@ -1193,23 +1192,8 @@ msgid "FP2 - Micro"
 msgstr ""
 
 #. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-screen
-msgid "FP3"
-msgstr ""
-
-#. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-display
 msgid "FP3 - Écran"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp4-screen
-msgid "FP4"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp5-screen
-msgid "FP5"
 msgstr ""
 
 #. module: commown_self_troubleshooting
@@ -1792,16 +1776,6 @@ msgid "Oui"
 msgstr ""
 
 #. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-camera
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-display
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp4-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp5-screen
-msgid "PH00"
-msgstr ""
-
-#. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
 msgid ""
 "Pendant le test, tenez le téléphone comme si vous appeliez, et parlez. Vous "
@@ -1927,7 +1901,6 @@ msgstr "N° d'ordre"
 #. module: commown_self_troubleshooting
 #: model:commown_self_troubleshooting.category,name:commown_self_troubleshooting.shiftphone-ts-cat
 #: model:ir.ui.view,website_meta_title:commown_self_troubleshooting.shiftphone-screen
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.shiftphone-screen
 msgid "Shiftphone"
 msgstr ""
 
@@ -1981,11 +1954,6 @@ msgstr ""
 #: model:project.tags,name:commown_self_troubleshooting.tag-to-callback
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.serenity
 msgid "Sérénité"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.shiftphone-screen
-msgid "T3"
 msgstr ""
 
 #. module: commown_self_troubleshooting
@@ -2317,66 +2285,6 @@ msgstr ""
 #. module: commown_self_troubleshooting
 #: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.step-contract-choice
 msgid "ici pour les ordinateurs  <i class=\"fa fa-external-link-alt\"/>"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.commercial
-msgid "issue-description-commercial"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.contract-termination
-msgid "issue-description-contract-termination"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-battery
-msgid "issue-description-fp2-battery"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-camera
-msgid "issue-description-fp2-camera"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp2-micro
-msgid "issue-description-fp2-micro"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.fp3-display
-msgid "issue-description-fp3-display"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.generic-issue
-msgid "issue-description-generic-issue"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.gs-day
-msgid "issue-description-gs"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.other
-msgid "issue-description-other"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.serenity
-msgid "issue-description-serenity"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.smartphone-screen
-msgid "issue-description-smartphone-screen"
-msgstr ""
-
-#. module: commown_self_troubleshooting
-#: model_terms:ir.ui.view,arch_db:commown_self_troubleshooting.theft-and-loss
-msgid "issue-description-theft-and-loss"
 msgstr ""
 
 #. module: commown_self_troubleshooting


### PR DESCRIPTION
This typo caused an issue for german customers trying to access the FP3 screen self-troubleshooting form. Indeed, the model name is used in the generic screen smartphone self-troubleshooting form to get the form within the page, to fetch all contracts associated with any given customer. (see commown_self_troubleshooting/data/Smartphone/screen/form.xml:L124)

As such, this lead to the program looking for a "commown_self_troubleshooting.fo3_screen_page" entity within the database, which can't exist, and lead to a crash for german customers.