### PR TITLE
[16.0][I18N] commown: Changed german translation of "My quotations" to invoke quotations directly

### DIFF
--- a/commown/i18n/de.po
+++ b/commown/i18n/de.po
@@ -379,7 +379,7 @@ msgstr "Ihre Bestellungen"
 #. module: commown
 #: model_terms:ir.ui.view,arch_db:commown.portal_my_home_sale
 msgid "My quotations"
-msgstr "Ihre Hinterlegte Kaution(en) / Genossenschaftsanteile"
+msgstr "Ihre Angebote"
 
 #. module: commown
 #: model_terms:ir.ui.view,arch_db:commown.portal_my_home_invoice


### PR DESCRIPTION
Previously, we used to call the Quotes menu as "My deposits / social shares", and translated it into the german as such. However, while we changed the english/french versions as "My quotations", we never changed the german translation to correspond.

As such, we fix it here.

Note: while the translation is not entirely accurate, since "Ihre Angebote" really means "Your Quotations", it fits with our other translations.