### PR TITLE
[16.0][FIX] commown: Renamed template with duplicate name

### DIFF
--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -155,7 +155,7 @@
     </xpath>
   </template>
 
-  <template id="product" inherit_id="website_sale_cart_selectable.product">
+  <template id="product_cart" inherit_id="website_sale_cart_selectable.product">
     <xpath
             expr="//t[@t-if='product.website_btn_addtocart_published']"
             position="attributes"


### PR DESCRIPTION
On line 190 of the same file is another template named "product", which led to two templates sharing a same external ID ("commown.product").

This leads to one of these templates either being completely overriden, or the templates being mixedand leading to a template issue.

For instance, if the view based on website_sale_cart_selectable.product was instead inheriting website_sale_b2b.product_b2b, then the template can crash upon the product page loading, as the required element in the that template is not found in product_b2b.