### PR TITLE
[16.0][FIX] commown: Fix close buttons on product details modal in order page (+ visual tweaks)

### DIFF
--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -84,12 +84,10 @@
             <div class="modal-header">
               <button
                                 type="button"
-                                class="close"
-                                data-dismiss="modal"
+                                class="btn-close"
+                                data-bs-dismiss="modal"
                                 aria-label="Close"
-                            >
-                <span aria-hidden="true">x</span>
-              </button>
+                            />
               <h4 class="modal-title">
                 <t t-esc="line.product_id.name" />
               </h4>
@@ -99,7 +97,7 @@
                             t-field="line.product_id.product_tmpl_id.website_description"
                         />
             <div class="modal-footer">
-              <button type="button" class="btn btn-default" data-dismiss="modal">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
                 Fermer
               </button>
             </div>

--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -82,15 +82,15 @@
         <div class="modal-dialog" role="document" style="width:80%">
           <div class="modal-content">
             <div class="modal-header">
+              <h4 class="modal-title">
+                <t t-esc="line.product_id.name" />
+              </h4>
               <button
                                 type="button"
                                 class="btn-close"
                                 data-bs-dismiss="modal"
                                 aria-label="Close"
                             />
-              <h4 class="modal-title">
-                <t t-esc="line.product_id.name" />
-              </h4>
             </div>
             <div
                             class="modal-body"

--- a/commown/views/website_sale_templates.xml
+++ b/commown/views/website_sale_templates.xml
@@ -79,7 +79,7 @@
                 tabindex="-1"
                 role="dialog"
             >
-        <div class="modal-dialog" role="document" style="width:80%">
+        <div class="modal-dialog modal-xl" role="document">
           <div class="modal-content">
             <div class="modal-header">
               <h4 class="modal-title">


### PR DESCRIPTION
# Current look
<img width="1912" height="948" alt="Capture d’écran du 2026-07-22 10-08-19" src="https://github.com/user-attachments/assets/307b0fcb-efbb-4289-9c8c-535074ed3ec4" />

# Updated look
<img width="1871" height="946" alt="Capture d’écran du 2026-07-22 10-01-56" src="https://github.com/user-attachments/assets/a985d1db-6e12-4688-adb5-de8e92d907a3" />
